### PR TITLE
Codex-generated pull request

### DIFF
--- a/bot/tgbot/tests/conftest.py
+++ b/bot/tgbot/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+
+os.environ.setdefault("BOT_TOKEN", "123456:TEST_TOKEN")
+os.environ.setdefault("BACKEND_API_KEY", "test-api-key")

--- a/bot/tgbot/tests/test_help_handler.py
+++ b/bot/tgbot/tests/test_help_handler.py
@@ -1,0 +1,20 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+pytestmark = pytest.mark.asyncio
+
+from tgbot.handlers.help import help_command
+
+
+async def test_help_command_replies_with_supported_commands() -> None:
+    message = AsyncMock()
+    message.from_user = SimpleNamespace(username="tester")
+
+    await help_command(message)
+
+    message.reply.assert_awaited_once()
+    reply_text = message.reply.await_args.args[0]
+    assert "Conversation with AI" in reply_text
+    assert "/weather" in reply_text
+    assert "/upcoming" in reply_text

--- a/bot/tgbot/tests/test_start_handler.py
+++ b/bot/tgbot/tests/test_start_handler.py
@@ -1,0 +1,39 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+pytestmark = pytest.mark.asyncio
+
+from tgbot.handlers.echo import command_start_handler
+
+
+async def test_start_handler_greets_allowed_user() -> None:
+    message = AsyncMock()
+    message.from_user = SimpleNamespace(id=100, full_name="Test User", username="tester")
+    user_cache = AsyncMock()
+    user_cache.is_allowed.return_value = True
+    config = SimpleNamespace(admins=[42])
+
+    await command_start_handler(message, user_cache, config)
+
+    message.answer.assert_awaited_once()
+    user_cache.is_allowed.assert_called_once_with(100)
+
+
+async def test_start_handler_notifies_admin_for_new_user(monkeypatch) -> None:
+    message = AsyncMock()
+    message.from_user = SimpleNamespace(id=100, full_name="Test User", username="tester")
+    user_cache = AsyncMock()
+    user_cache.is_allowed.return_value = False
+    config = SimpleNamespace(admins=[42])
+    send_message_mock = AsyncMock()
+
+    monkeypatch.setattr("tgbot.handlers.echo.bot.send_message", send_message_mock)
+
+    await command_start_handler(message, user_cache, config)
+
+    message.answer.assert_awaited_once_with(
+        "You are not allowed to use this bot. Permission request has been sent to the administrator."
+    )
+    send_message_mock.assert_awaited_once()
+    assert send_message_mock.await_args.kwargs["chat_id"] == 42

--- a/bot/tgbot/tests/test_weather_handler.py
+++ b/bot/tgbot/tests/test_weather_handler.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import AsyncMock
+
+pytestmark = pytest.mark.asyncio
+
+from aiogram.filters import CommandObject
+
+from tgbot.handlers.weather import weather_command
+
+
+async def test_weather_command_requires_city_argument() -> None:
+    message = AsyncMock()
+    command = CommandObject(prefix="/", command="weather", args=None)
+
+    await weather_command(message, command)
+
+    message.reply.assert_awaited_once_with(
+        "❓ Please provide a city name.\nExample: /weather London"
+    )
+
+
+async def test_weather_command_rejects_more_than_one_city_token() -> None:
+    message = AsyncMock()
+    command = CommandObject(prefix="/", command="weather", args="New York")
+
+    await weather_command(message, command)
+
+    message.reply.assert_awaited_once_with(
+        "❓ Please provide a city name.\nExample: /weather London"
+    )
+
+
+async def test_weather_command_fetches_weather_for_single_city(monkeypatch) -> None:
+    message = AsyncMock()
+    command = CommandObject(prefix="/", command="weather", args="London")
+    weather_service_mock = AsyncMock(return_value="Sunny and 20°C")
+
+    monkeypatch.setattr(
+        "tgbot.handlers.weather.weather_service.get_current_weather", weather_service_mock
+    )
+
+    await weather_command(message, command)
+
+    weather_service_mock.assert_awaited_once_with("London")
+    message.answer.assert_awaited_once_with("Sunny and 20°C")


### PR DESCRIPTION
### **User description**
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996f691f25083268b7a746d782ac21f)


___

### **PR Type**
Tests


___

### **Description**
- Add unit tests for bot handlers using pytest and aiogram_tests

- Test help command handler with supported commands validation

- Test start command handler with user permission checks

- Test weather command handler with argument validation

- Add test configuration with environment variables setup


___



### File Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Test configuration with environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bot/tgbot/tests/conftest.py

<ul><li>Set default environment variables for testing (<code>BOT_TOKEN</code> and <br><code>BACKEND_API_KEY</code>)<br> <li> Provides test configuration for bot initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/mezgoodle/Vesta/pull/21/files#diff-12eb927bde277b14631b40df0270fd948860d682334fa7e04975f7391093a32e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_help_handler.py</strong><dd><code>Help command handler unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bot/tgbot/tests/test_help_handler.py

<ul><li>Test <code>help_command</code> handler with mocked message object<br> <li> Verify reply is sent with supported commands listed<br> <li> Assert response contains "Conversation with AI", "/weather", and <br>"/upcoming"</ul>


</details>


  </td>
  <td><a href="https://github.com/mezgoodle/Vesta/pull/21/files#diff-fee5745c515395245e5e1438cfbe10db38147e20d21eaa5c44f19b588297b2eb">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_start_handler.py</strong><dd><code>Start command handler unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bot/tgbot/tests/test_start_handler.py

<ul><li>Test <code>command_start_handler</code> for allowed users with greeting response<br> <li> Test notification to admin when new user is not allowed<br> <li> Mock user cache and config dependencies<br> <li> Verify appropriate messages sent based on user permission status</ul>


</details>


  </td>
  <td><a href="https://github.com/mezgoodle/Vesta/pull/21/files#diff-d5882416df8429b0187ec3078a0524a3faaf2f0a72801c2fe2752ee9cf49cbf4">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_weather_handler.py</strong><dd><code>Weather command handler unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bot/tgbot/tests/test_weather_handler.py

<ul><li>Test <code>weather_command</code> rejects missing city argument<br> <li> Test rejection of multi-word city names (more than one token)<br> <li> Test successful weather fetch for single city with mocked service<br> <li> Verify correct error messages and API calls</ul>


</details>


  </td>
  <td><a href="https://github.com/mezgoodle/Vesta/pull/21/files#diff-d2c5442dae7483d72ae9574bd4f04b258055990621daeaab91cf49708a1dcea0">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

___

