### PR TITLE
Add Flutter mobile_app module with auth/chat/voice/devices and JARVIS UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!mobile_app/lib/
+!mobile_app/lib/**
 lib64/
 parts/
 sdist/

--- a/mobile_app/.gitignore
+++ b/mobile_app/.gitignore
@@ -1,0 +1,6 @@
+.dart_tool/
+.packages
+.pub-cache/
+.pub/
+build/
+android/.gradle/

--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -1,0 +1,70 @@
+# Vesta Mobile App (Flutter, Android)
+
+Мобільний клієнт для Vesta backend з auth, chat, voice loop та Home Control.
+
+## 1) Передумови
+
+- Flutter SDK 3.22+ (stable)
+- Android SDK + Android Studio (або встановлені Android command-line tools)
+- Працюючий backend Vesta
+
+## 2) Налаштування
+
+```bash
+cd mobile_app
+flutter pub get
+```
+
+## 3) Конфіг API Base URL
+
+Додаток читає API URL з `--dart-define`:
+
+- `API_BASE_URL` (дефолт: `http://10.0.2.2:8000`)
+
+Приклад запуску на Android emulator:
+
+```bash
+flutter run \
+  --dart-define=API_BASE_URL=http://10.0.2.2:8000
+```
+
+> Для фізичного Android-девайса використовуйте IP машини у локальній мережі, наприклад `http://192.168.1.50:8000`.
+
+## 4) Що реалізовано
+
+- **Auth** через `POST /api/v1/login/access-token` (x-www-form-urlencoded)
+- **Secure token storage** через `flutter_secure_storage`
+- **Chat** через `POST /api/v1/chat/process` з `want_voice=true`
+- **Voice loop**:
+  - STT через `speech_to_text`
+  - запит в `/chat/process`
+  - відтворення `voice_audio` (base64)
+  - fallback на `POST /api/v1/tts/synthesize`
+- **Home Control**:
+  - читання девайсів (`GET /api/v1/devices`)
+  - CRUD керування девайсами (`/api/v1/devices/*`)
+
+## 5) Запуск
+
+```bash
+flutter run --dart-define=API_BASE_URL=http://10.0.2.2:8000
+```
+
+## 6) Debug APK build
+
+```bash
+flutter build apk --debug \
+  --dart-define=API_BASE_URL=http://10.0.2.2:8000
+```
+
+APK після білду:
+
+- `build/app/outputs/flutter-apk/app-debug.apk`
+
+## 7) Доступи Android (мікрофон)
+
+У `android/app/src/main/AndroidManifest.xml` додано:
+
+- `android.permission.RECORD_AUDIO`
+- `android.permission.INTERNET`
+

--- a/mobile_app/analysis_options.yaml
+++ b/mobile_app/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/mobile_app/android/app/build.gradle
+++ b/mobile_app/android/app/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    namespace 'com.vesta.mobile_app'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.vesta.mobile_app'
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName '0.1.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+}
+
+dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.9.24'
+}

--- a/mobile_app/android/app/proguard-rules.pro
+++ b/mobile_app/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Keep default proguard rules for debug/release parity.

--- a/mobile_app/android/app/src/main/AndroidManifest.xml
+++ b/mobile_app/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.vesta.mobile_app">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+    <application
+        android:label="Vesta Mobile"
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/mobile_app/android/app/src/main/kotlin/com/vesta/mobile_app/MainActivity.kt
+++ b/mobile_app/android/app/src/main/kotlin/com/vesta/mobile_app/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.vesta.mobile_app
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity()

--- a/mobile_app/android/app/src/main/res/values/styles.xml
+++ b/mobile_app/android/app/src/main/res/values/styles.xml
@@ -1,0 +1,5 @@
+<resources>
+    <style name="LaunchTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:windowBackground">@android:color/black</item>
+    </style>
+</resources>

--- a/mobile_app/android/build.gradle
+++ b/mobile_app/android/build.gradle
@@ -1,0 +1,19 @@
+buildscript {
+    ext.kotlin_version = '1.9.24'
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.5.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/mobile_app/android/gradle.properties
+++ b/mobile_app/android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/mobile_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip

--- a/mobile_app/android/settings.gradle
+++ b/mobile_app/android/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'mobile_app'
+include ':app'

--- a/mobile_app/lib/app.dart
+++ b/mobile_app/lib/app.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'core/config/app_config.dart';
+import 'core/network/api_client.dart';
+import 'core/storage/token_storage.dart';
+import 'features/auth/data/auth_repository.dart';
+import 'features/auth/presentation/auth_controller.dart';
+import 'features/auth/presentation/login_screen.dart';
+import 'features/chat/data/chat_repository.dart';
+import 'features/chat/presentation/chat_controller.dart';
+import 'features/chat/presentation/chat_screen.dart';
+import 'features/devices/data/device_repository.dart';
+import 'features/devices/presentation/device_controller.dart';
+import 'features/devices/presentation/home_control_screen.dart';
+import 'features/voice/data/audio_player_service.dart';
+import 'features/voice/data/speech_service.dart';
+
+class VestaApp extends StatelessWidget {
+  const VestaApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final tokenStorage = TokenStorage();
+    final apiClient = ApiClient(
+      baseUrl: AppConfig.apiBaseUrl,
+      tokenStorage: tokenStorage,
+    );
+
+    return MultiProvider(
+      providers: [
+        Provider<TokenStorage>.value(value: tokenStorage),
+        Provider<ApiClient>.value(value: apiClient),
+        ProxyProvider<ApiClient, AuthRepository>(
+          update: (_, client, __) => AuthRepository(client),
+        ),
+        ProxyProvider<ApiClient, ChatRepository>(
+          update: (_, client, __) => ChatRepository(client),
+        ),
+        ProxyProvider<ApiClient, DeviceRepository>(
+          update: (_, client, __) => DeviceRepository(client),
+        ),
+        Provider<SpeechService>(create: (_) => SpeechService()),
+        Provider<AudioPlayerService>(create: (_) => AudioPlayerService()),
+        ChangeNotifierProxyProvider2<AuthRepository, TokenStorage, AuthController>(
+          create: (_) => AuthController(),
+          update: (_, repo, storage, controller) =>
+              controller!..bind(repo: repo, tokenStorage: storage),
+        ),
+        ChangeNotifierProxyProvider3<ChatRepository, SpeechService,
+            AudioPlayerService, ChatController>(
+          create: (_) => ChatController(),
+          update: (_, repo, speech, audio, controller) =>
+              controller!..bind(repo: repo, speechService: speech, audioService: audio),
+        ),
+        ChangeNotifierProxyProvider<DeviceRepository, DeviceController>(
+          create: (_) => DeviceController(),
+          update: (_, repo, controller) => controller!..bind(repo),
+        ),
+      ],
+      child: MaterialApp(
+        title: 'Vesta Mobile',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(
+          brightness: Brightness.dark,
+          scaffoldBackgroundColor: const Color(0xFF070B14),
+          colorScheme: const ColorScheme.dark(
+            primary: Color(0xFF5DE2FF),
+            secondary: Color(0xFF00B7FF),
+          ),
+        ),
+        home: Consumer<AuthController>(
+          builder: (_, auth, __) {
+            if (auth.isLoading) {
+              return const Scaffold(
+                body: Center(child: CircularProgressIndicator()),
+              );
+            }
+            return auth.isAuthenticated ? const _RootTabs() : const LoginScreen();
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _RootTabs extends StatefulWidget {
+  const _RootTabs();
+
+  @override
+  State<_RootTabs> createState() => _RootTabsState();
+}
+
+class _RootTabsState extends State<_RootTabs> {
+  int index = 0;
+
+  final screens = const [
+    ChatScreen(),
+    HomeControlScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: screens[index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: index,
+        onTap: (value) => setState(() => index = value),
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.smart_toy), label: 'JARVIS'),
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home Control'),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/core/config/app_config.dart
+++ b/mobile_app/lib/core/config/app_config.dart
@@ -1,0 +1,6 @@
+class AppConfig {
+  static const apiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'http://10.0.2.2:8000',
+  );
+}

--- a/mobile_app/lib/core/network/api_client.dart
+++ b/mobile_app/lib/core/network/api_client.dart
@@ -1,0 +1,20 @@
+import 'package:dio/dio.dart';
+
+import '../storage/token_storage.dart';
+import 'auth_interceptor.dart';
+
+class ApiClient {
+  ApiClient({required String baseUrl, required TokenStorage tokenStorage})
+      : dio = Dio(
+          BaseOptions(
+            baseUrl: baseUrl,
+            connectTimeout: const Duration(seconds: 15),
+            receiveTimeout: const Duration(seconds: 45),
+            headers: {'Accept': 'application/json'},
+          ),
+        ) {
+    dio.interceptors.add(AuthInterceptor(tokenStorage));
+  }
+
+  final Dio dio;
+}

--- a/mobile_app/lib/core/network/auth_interceptor.dart
+++ b/mobile_app/lib/core/network/auth_interceptor.dart
@@ -1,0 +1,21 @@
+import 'package:dio/dio.dart';
+
+import '../storage/token_storage.dart';
+
+class AuthInterceptor extends Interceptor {
+  AuthInterceptor(this._tokenStorage);
+
+  final TokenStorage _tokenStorage;
+
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    final token = await _tokenStorage.readToken();
+    if (token != null && token.isNotEmpty) {
+      options.headers['Authorization'] = 'Bearer $token';
+    }
+    super.onRequest(options, handler);
+  }
+}

--- a/mobile_app/lib/core/storage/token_storage.dart
+++ b/mobile_app/lib/core/storage/token_storage.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class TokenStorage {
+  static const _tokenKey = 'auth_access_token';
+
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+
+  Future<void> saveToken(String token) =>
+      _storage.write(key: _tokenKey, value: token);
+
+  Future<String?> readToken() => _storage.read(key: _tokenKey);
+
+  Future<void> clear() => _storage.delete(key: _tokenKey);
+}

--- a/mobile_app/lib/features/auth/data/auth_repository.dart
+++ b/mobile_app/lib/features/auth/data/auth_repository.dart
@@ -1,0 +1,23 @@
+import 'package:dio/dio.dart';
+
+import '../../../core/network/api_client.dart';
+
+class AuthRepository {
+  AuthRepository(this._client);
+
+  final ApiClient _client;
+
+  Future<String> login({required String email, required String password}) async {
+    final response = await _client.dio.post<Map<String, dynamic>>(
+      '/api/v1/login/access-token',
+      data: {'username': email, 'password': password},
+      options: Options(contentType: Headers.formUrlEncodedContentType),
+    );
+
+    final token = response.data?['access_token'] as String?;
+    if (token == null || token.isEmpty) {
+      throw Exception('No access_token in response');
+    }
+    return token;
+  }
+}

--- a/mobile_app/lib/features/auth/presentation/auth_controller.dart
+++ b/mobile_app/lib/features/auth/presentation/auth_controller.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../core/storage/token_storage.dart';
+import '../data/auth_repository.dart';
+
+class AuthController extends ChangeNotifier {
+  AuthRepository? _repo;
+  TokenStorage? _tokenStorage;
+
+  bool _isLoading = true;
+  bool _isAuthenticated = false;
+  String? error;
+
+  bool get isLoading => _isLoading;
+  bool get isAuthenticated => _isAuthenticated;
+
+  Future<void> bind({
+    required AuthRepository repo,
+    required TokenStorage tokenStorage,
+  }) async {
+    _repo = repo;
+    _tokenStorage = tokenStorage;
+    await _restoreSession();
+  }
+
+  Future<void> _restoreSession() async {
+    if (!_isLoading) return;
+    final token = await _tokenStorage?.readToken();
+    _isAuthenticated = token != null && token.isNotEmpty;
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  Future<bool> login(String email, String password) async {
+    error = null;
+    notifyListeners();
+
+    try {
+      final token = await _repo!.login(email: email, password: password);
+      await _tokenStorage!.saveToken(token);
+      _isAuthenticated = true;
+      notifyListeners();
+      return true;
+    } catch (e) {
+      error = e.toString();
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<void> logout() async {
+    await _tokenStorage?.clear();
+    _isAuthenticated = false;
+    notifyListeners();
+  }
+}

--- a/mobile_app/lib/features/auth/presentation/login_screen.dart
+++ b/mobile_app/lib/features/auth/presentation/login_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'auth_controller.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final emailController = TextEditingController();
+  final passwordController = TextEditingController();
+  bool submitting = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = context.watch<AuthController>();
+
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Card(
+            margin: const EdgeInsets.all(20),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('Vesta Login', style: TextStyle(fontSize: 22)),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: emailController,
+                    decoration: const InputDecoration(labelText: 'Email'),
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: passwordController,
+                    obscureText: true,
+                    decoration: const InputDecoration(labelText: 'Password'),
+                  ),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: submitting
+                          ? null
+                          : () async {
+                              setState(() => submitting = true);
+                              await auth.login(
+                                emailController.text.trim(),
+                                passwordController.text,
+                              );
+                              if (mounted) {
+                                setState(() => submitting = false);
+                              }
+                            },
+                      child: Text(submitting ? 'Signing in...' : 'Sign in'),
+                    ),
+                  ),
+                  if (auth.error != null) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      auth.error!,
+                      style: const TextStyle(color: Colors.redAccent),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/features/chat/data/chat_models.dart
+++ b/mobile_app/lib/features/chat/data/chat_models.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+
+class ChatRequest {
+  ChatRequest({
+    required this.userId,
+    required this.message,
+    this.wantVoice = true,
+    this.sessionId,
+  });
+
+  final int userId;
+  final String message;
+  final bool wantVoice;
+  final int? sessionId;
+
+  Map<String, dynamic> toJson() => {
+        'user_id': userId,
+        'message': message,
+        'want_voice': wantVoice,
+        'session_id': sessionId,
+      };
+}
+
+class ChatResponseModel {
+  ChatResponseModel({
+    required this.response,
+    required this.sessionId,
+    this.voiceAudioBase64,
+  });
+
+  final String response;
+  final int sessionId;
+  final String? voiceAudioBase64;
+
+  factory ChatResponseModel.fromJson(Map<String, dynamic> json) {
+    return ChatResponseModel(
+      response: json['response'] as String,
+      sessionId: json['session_id'] as int,
+      voiceAudioBase64: json['voice_audio'] as String?,
+    );
+  }
+
+  List<int>? decodeVoiceBytes() {
+    final input = voiceAudioBase64;
+    if (input == null || input.isEmpty) return null;
+    return base64Decode(input);
+  }
+}

--- a/mobile_app/lib/features/chat/data/chat_repository.dart
+++ b/mobile_app/lib/features/chat/data/chat_repository.dart
@@ -1,0 +1,27 @@
+import 'package:dio/dio.dart';
+
+import '../../../core/network/api_client.dart';
+import 'chat_models.dart';
+
+class ChatRepository {
+  ChatRepository(this._client);
+
+  final ApiClient _client;
+
+  Future<ChatResponseModel> process(ChatRequest request) async {
+    final response = await _client.dio.post<Map<String, dynamic>>(
+      '/api/v1/chat/process',
+      data: request.toJson(),
+    );
+    return ChatResponseModel.fromJson(response.data!);
+  }
+
+  Future<List<int>> synthesizeFallback(String text) async {
+    final response = await _client.dio.post<List<int>>(
+      '/api/v1/tts/synthesize',
+      data: {'text': text},
+      options: Options(responseType: ResponseType.bytes),
+    );
+    return response.data ?? <int>[];
+  }
+}

--- a/mobile_app/lib/features/chat/presentation/chat_controller.dart
+++ b/mobile_app/lib/features/chat/presentation/chat_controller.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/foundation.dart';
+
+import '../../voice/data/audio_player_service.dart';
+import '../../voice/data/speech_service.dart';
+import '../data/chat_models.dart';
+import '../data/chat_repository.dart';
+
+enum JarvisState { idle, listening, thinking, speaking }
+
+class ChatMessage {
+  ChatMessage(this.role, this.text);
+
+  final String role;
+  final String text;
+}
+
+class ChatController extends ChangeNotifier {
+  static const int demoUserId = 1;
+
+  ChatRepository? _repo;
+  SpeechService? _speechService;
+  AudioPlayerService? _audioService;
+
+  final List<ChatMessage> messages = [];
+
+  JarvisState state = JarvisState.idle;
+  String draftSpeech = '';
+  int? sessionId;
+
+  void bind({
+    required ChatRepository repo,
+    required SpeechService speechService,
+    required AudioPlayerService audioService,
+  }) {
+    _repo = repo;
+    _speechService = speechService;
+    _audioService = audioService;
+  }
+
+  String get statusText {
+    switch (state) {
+      case JarvisState.listening:
+        return 'Listening';
+      case JarvisState.thinking:
+        return 'Thinking';
+      case JarvisState.speaking:
+        return 'Speaking';
+      case JarvisState.idle:
+        return 'Ready';
+    }
+  }
+
+  Future<void> sendText(String text) async {
+    if (text.trim().isEmpty) return;
+    messages.add(ChatMessage('user', text));
+    state = JarvisState.thinking;
+    notifyListeners();
+
+    final response = await _repo!.process(
+      ChatRequest(
+        userId: demoUserId,
+        message: text,
+        wantVoice: true,
+        sessionId: sessionId,
+      ),
+    );
+
+    sessionId = response.sessionId;
+    messages.add(ChatMessage('assistant', response.response));
+
+    state = JarvisState.speaking;
+    notifyListeners();
+
+    final decodedVoice = response.decodeVoiceBytes();
+    if (decodedVoice != null && decodedVoice.isNotEmpty) {
+      await _audioService!.playBytes(decodedVoice);
+    } else {
+      final fallback = await _repo!.synthesizeFallback(response.response);
+      await _audioService!.playBytes(fallback);
+    }
+
+    state = JarvisState.idle;
+    notifyListeners();
+  }
+
+  Future<void> startListening() async {
+    final isReady = await _speechService!.initialize();
+    if (!isReady) return;
+
+    state = JarvisState.listening;
+    draftSpeech = '';
+    notifyListeners();
+
+    await _speechService!.start(
+      onResult: (text, isFinal) async {
+        draftSpeech = text;
+        notifyListeners();
+
+        if (isFinal && text.trim().isNotEmpty) {
+          await _speechService!.stop();
+          await sendText(text);
+        }
+      },
+    );
+  }
+
+  Future<void> stopListening() async {
+    await _speechService?.stop();
+    if (state == JarvisState.listening) {
+      state = JarvisState.idle;
+      notifyListeners();
+    }
+  }
+}

--- a/mobile_app/lib/features/chat/presentation/chat_screen.dart
+++ b/mobile_app/lib/features/chat/presentation/chat_screen.dart
@@ -1,0 +1,195 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../auth/presentation/auth_controller.dart';
+import '../../voice/presentation/voice_status_badge.dart';
+import 'chat_controller.dart';
+
+class ChatScreen extends StatefulWidget {
+  const ChatScreen({super.key});
+
+  @override
+  State<ChatScreen> createState() => _ChatScreenState();
+}
+
+class _ChatScreenState extends State<ChatScreen> {
+  final controller = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final chat = context.watch<ChatController>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('JARVIS'),
+        actions: [
+          IconButton(
+            onPressed: () => context.read<AuthController>().logout(),
+            icon: const Icon(Icons.logout),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          const SizedBox(height: 16),
+          _JarvisCore(status: chat.statusText, state: chat.state),
+          if (chat.draftSpeech.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: Text('"${chat.draftSpeech}"'),
+            ),
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(12),
+              itemCount: chat.messages.length,
+              itemBuilder: (_, index) {
+                final item = chat.messages[index];
+                final isUser = item.role == 'user';
+                return Align(
+                  alignment:
+                      isUser ? Alignment.centerRight : Alignment.centerLeft,
+                  child: Card(
+                    color: isUser
+                        ? const Color(0xFF123E52)
+                        : const Color(0xFF1A1F2B),
+                    child: Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: Text(item.text),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: controller,
+                    decoration: const InputDecoration(hintText: 'Type a message'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                IconButton(
+                  onPressed: () async {
+                    final text = controller.text;
+                    controller.clear();
+                    await chat.sendText(text);
+                  },
+                  icon: const Icon(Icons.send),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: _VoiceActions(chat: chat),
+    );
+  }
+}
+
+class _VoiceActions extends StatelessWidget {
+  const _VoiceActions({required this.chat});
+
+  final ChatController chat;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        FloatingActionButton.extended(
+          heroTag: 'tap_to_talk',
+          onPressed: () => chat.startListening(),
+          icon: const Icon(Icons.mic),
+          label: const Text('Tap to talk'),
+        ),
+        const SizedBox(height: 8),
+        GestureDetector(
+          onLongPressStart: (_) => chat.startListening(),
+          onLongPressEnd: (_) => chat.stopListening(),
+          child: FloatingActionButton.extended(
+            heroTag: 'hold_to_talk',
+            onPressed: () {},
+            icon: const Icon(Icons.hearing),
+            label: const Text('Hold to talk'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _JarvisCore extends StatefulWidget {
+  const _JarvisCore({required this.status, required this.state});
+
+  final String status;
+  final JarvisState state;
+
+  @override
+  State<_JarvisCore> createState() => _JarvisCoreState();
+}
+
+class _JarvisCoreState extends State<_JarvisCore>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController animation;
+
+  @override
+  void initState() {
+    super.initState();
+    animation = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 2),
+    )..repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    animation.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final glowMultiplier = switch (widget.state) {
+      JarvisState.listening => 1.5,
+      JarvisState.thinking => 1.2,
+      JarvisState.speaking => 1.8,
+      JarvisState.idle => 1.0,
+    };
+
+    return Column(
+      children: [
+        AnimatedBuilder(
+          animation: animation,
+          builder: (_, __) {
+            final scale = 48 + (math.sin(animation.value * math.pi) * 16);
+            return Container(
+              width: scale,
+              height: scale,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: const Color(0xFF52E8FF),
+                boxShadow: [
+                  BoxShadow(
+                    color: const Color(0xFF52E8FF)
+                        .withOpacity(0.55 * glowMultiplier),
+                    blurRadius: 40 * glowMultiplier,
+                    spreadRadius: 6 * glowMultiplier,
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+        const SizedBox(height: 10),
+        VoiceStatusBadge(label: widget.status),
+      ],
+    );
+  }
+}

--- a/mobile_app/lib/features/devices/data/device_model.dart
+++ b/mobile_app/lib/features/devices/data/device_model.dart
@@ -1,0 +1,41 @@
+class SmartDevice {
+  SmartDevice({
+    required this.id,
+    required this.name,
+    required this.entityId,
+    this.deviceType,
+    this.room,
+    required this.userId,
+  });
+
+  final int id;
+  final String name;
+  final String entityId;
+  final String? deviceType;
+  final String? room;
+  final int userId;
+
+  factory SmartDevice.fromJson(Map<String, dynamic> json) => SmartDevice(
+        id: json['id'] as int,
+        name: json['name'] as String,
+        entityId: json['entity_id'] as String,
+        deviceType: json['device_type'] as String?,
+        room: json['room'] as String?,
+        userId: json['user_id'] as int,
+      );
+
+  Map<String, dynamic> toCreateJson() => {
+        'name': name,
+        'entity_id': entityId,
+        'device_type': deviceType,
+        'room': room,
+        'user_id': userId,
+      };
+
+  Map<String, dynamic> toUpdateJson() => {
+        'name': name,
+        'entity_id': entityId,
+        'device_type': deviceType,
+        'room': room,
+      };
+}

--- a/mobile_app/lib/features/devices/data/device_repository.dart
+++ b/mobile_app/lib/features/devices/data/device_repository.dart
@@ -1,0 +1,40 @@
+import '../../../core/network/api_client.dart';
+import 'device_model.dart';
+
+class DeviceRepository {
+  DeviceRepository(this._client);
+
+  final ApiClient _client;
+
+  Future<List<SmartDevice>> getDevices({required int userId}) async {
+    final response = await _client.dio.get<List<dynamic>>(
+      '/api/v1/devices/',
+      queryParameters: {'user_id': userId},
+    );
+
+    final list = response.data ?? [];
+    return list
+        .map((item) => SmartDevice.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<SmartDevice> createDevice(SmartDevice device) async {
+    final response = await _client.dio.post<Map<String, dynamic>>(
+      '/api/v1/devices/',
+      data: device.toCreateJson(),
+    );
+    return SmartDevice.fromJson(response.data!);
+  }
+
+  Future<SmartDevice> updateDevice(SmartDevice device) async {
+    final response = await _client.dio.put<Map<String, dynamic>>(
+      '/api/v1/devices/${device.id}',
+      data: device.toUpdateJson(),
+    );
+    return SmartDevice.fromJson(response.data!);
+  }
+
+  Future<void> deleteDevice(int deviceId) async {
+    await _client.dio.delete('/api/v1/devices/$deviceId');
+  }
+}

--- a/mobile_app/lib/features/devices/presentation/device_controller.dart
+++ b/mobile_app/lib/features/devices/presentation/device_controller.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/foundation.dart';
+
+import '../data/device_model.dart';
+import '../data/device_repository.dart';
+
+class DeviceController extends ChangeNotifier {
+  static const int demoUserId = 1;
+
+  DeviceRepository? _repository;
+
+  bool loading = false;
+  String? error;
+  List<SmartDevice> devices = [];
+
+  void bind(DeviceRepository repository) {
+    _repository = repository;
+  }
+
+  Future<void> loadDevices() async {
+    loading = true;
+    error = null;
+    notifyListeners();
+
+    try {
+      devices = await _repository!.getDevices(userId: demoUserId);
+    } catch (e) {
+      error = e.toString();
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> createDevice({
+    required String name,
+    required String entityId,
+    String? room,
+    String? type,
+  }) async {
+    final newDevice = SmartDevice(
+      id: 0,
+      name: name,
+      entityId: entityId,
+      room: room,
+      deviceType: type,
+      userId: demoUserId,
+    );
+    await _repository!.createDevice(newDevice);
+    await loadDevices();
+  }
+
+  Future<void> toggleRename(SmartDevice device) async {
+    final updated = SmartDevice(
+      id: device.id,
+      name: '${device.name} •',
+      entityId: device.entityId,
+      room: device.room,
+      deviceType: device.deviceType,
+      userId: device.userId,
+    );
+    await _repository!.updateDevice(updated);
+    await loadDevices();
+  }
+
+  Future<void> delete(int id) async {
+    await _repository!.deleteDevice(id);
+    await loadDevices();
+  }
+}

--- a/mobile_app/lib/features/devices/presentation/home_control_screen.dart
+++ b/mobile_app/lib/features/devices/presentation/home_control_screen.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'device_controller.dart';
+
+class HomeControlScreen extends StatefulWidget {
+  const HomeControlScreen({super.key});
+
+  @override
+  State<HomeControlScreen> createState() => _HomeControlScreenState();
+}
+
+class _HomeControlScreenState extends State<HomeControlScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<DeviceController>().loadDevices();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final devices = context.watch<DeviceController>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home Control')),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _showCreateDialog(context),
+        icon: const Icon(Icons.add),
+        label: const Text('Add device'),
+      ),
+      body: devices.loading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: devices.loadDevices,
+              child: ListView(
+                padding: const EdgeInsets.all(12),
+                children: [
+                  if (devices.error != null)
+                    Text(
+                      devices.error!,
+                      style: const TextStyle(color: Colors.redAccent),
+                    ),
+                  ...devices.devices.map(
+                    (device) => Card(
+                      child: ListTile(
+                        title: Text(device.name),
+                        subtitle: Text(
+                          '${device.entityId} • ${device.room ?? 'Unknown room'}',
+                        ),
+                        trailing: Wrap(
+                          spacing: 8,
+                          children: [
+                            IconButton(
+                              icon: const Icon(Icons.edit),
+                              onPressed: () => devices.toggleRename(device),
+                            ),
+                            IconButton(
+                              icon: const Icon(Icons.delete),
+                              onPressed: () => devices.delete(device.id),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+
+  Future<void> _showCreateDialog(BuildContext context) async {
+    final nameCtrl = TextEditingController();
+    final entityCtrl = TextEditingController();
+    final roomCtrl = TextEditingController();
+
+    await showDialog<void>(
+      context: context,
+      builder: (_) {
+        return AlertDialog(
+          title: const Text('Create device'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: nameCtrl,
+                decoration: const InputDecoration(labelText: 'Name'),
+              ),
+              TextField(
+                controller: entityCtrl,
+                decoration: const InputDecoration(labelText: 'Entity ID'),
+              ),
+              TextField(
+                controller: roomCtrl,
+                decoration: const InputDecoration(labelText: 'Room'),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () async {
+                await context.read<DeviceController>().createDevice(
+                      name: nameCtrl.text,
+                      entityId: entityCtrl.text,
+                      room: roomCtrl.text.isEmpty ? null : roomCtrl.text,
+                    );
+                if (context.mounted) Navigator.pop(context);
+              },
+              child: const Text('Create'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/mobile_app/lib/features/voice/data/audio_player_service.dart
+++ b/mobile_app/lib/features/voice/data/audio_player_service.dart
@@ -1,0 +1,12 @@
+import 'dart:typed_data';
+
+import 'package:audioplayers/audioplayers.dart';
+
+class AudioPlayerService {
+  final AudioPlayer _player = AudioPlayer();
+
+  Future<void> playBytes(List<int> bytes) async {
+    if (bytes.isEmpty) return;
+    await _player.play(BytesSource(Uint8List.fromList(bytes)));
+  }
+}

--- a/mobile_app/lib/features/voice/data/speech_service.dart
+++ b/mobile_app/lib/features/voice/data/speech_service.dart
@@ -1,0 +1,20 @@
+import 'package:speech_to_text/speech_to_text.dart';
+
+class SpeechService {
+  final SpeechToText _speechToText = SpeechToText();
+
+  Future<bool> initialize() => _speechToText.initialize();
+
+  Future<void> start({
+    required void Function(String text, bool isFinal) onResult,
+  }) async {
+    await _speechToText.listen(
+      onResult: (result) {
+        onResult(result.recognizedWords, result.finalResult);
+      },
+      listenMode: ListenMode.confirmation,
+    );
+  }
+
+  Future<void> stop() => _speechToText.stop();
+}

--- a/mobile_app/lib/features/voice/presentation/voice_status_badge.dart
+++ b/mobile_app/lib/features/voice/presentation/voice_status_badge.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class VoiceStatusBadge extends StatelessWidget {
+  const VoiceStatusBadge({super.key, required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.white10,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(label),
+    );
+  }
+}

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+import 'app.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const VestaApp());
+}

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,0 +1,25 @@
+name: mobile_app
+description: Vesta mobile client with JARVIS-like voice assistant.
+publish_to: 'none'
+version: 0.1.0+1
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.8
+  dio: ^5.6.0
+  flutter_secure_storage: ^9.2.2
+  provider: ^6.1.2
+  speech_to_text: ^7.0.0
+  audioplayers: ^6.1.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
### Motivation
- Provide a first-class Android-targeted Flutter client for Vesta implementing auth, conversational chat with voice, and home device control. 
- Ship core networking and secure token storage so the mobile app can authenticate and call backend endpoints (`/login/access-token`, `/chat/process`, `/tts/synthesize`, `/devices/*`).
- Enable an interactive JARVIS-style voice loop (STT → chat → TTS/playback) and a Home Control UI to manage smart devices. 

### Description
- Add new `mobile_app/` Flutter module scaffold including `pubspec.yaml`, Android Gradle files, `AndroidManifest.xml`, `MainActivity`, and basic dark theme UI. 
- Implement core stack: `core/network/ApiClient` (Dio) and `core/network/AuthInterceptor` for Bearer tokens, plus `core/storage/TokenStorage` using `flutter_secure_storage`. 
- Implement `auth` feature with `AuthRepository` calling `POST /api/v1/login/access-token`, `AuthController` for session restore/logout, and `LoginScreen` UI. 
- Implement `chat` feature with `ChatRepository` calling `POST /api/v1/chat/process` (`want_voice=true`), `ChatResponse` base64 `voice_audio` decoding, `ChatController` state machine (Listening/Thinking/Speaking), and `ChatScreen` + animated JARVIS core UI. 
- Implement `voice` feature: `SpeechService` (using `speech_to_text`) for on-device STT and `AudioPlayerService` (using `audioplayers`) to play decoded voice bytes, with fallback to `POST /api/v1/tts/synthesize` when `voice_audio` is not present. 
- Implement `devices` feature with `DeviceRepository`, `DeviceController`, and `HomeControlScreen` supporting list/create/update/delete flows against `/api/v1/devices/*`. 
- Add `mobile_app/README.md` with prerequisites, `API_BASE_URL` configuration via `--dart-define`, run and debug APK build instructions, and Android microphone/Internet permissions. 
- Note: controllers currently use a demo `user_id = 1` and should be wired to authenticated user details in a follow-up task. 

### Testing
- Ran repository verification commands: `git status --short` succeeded and shows the `mobile_app/` addition. 
- Attempted SDK checks: `flutter --version` failed because Flutter SDK is not available in this environment (`/bin/bash: flutter: command not found`). 
- Attempted `dart --version` which also failed due to missing Dart SDK (`/bin/bash: dart: command not found`). 
- Because Flutter/Dart SDKs are unavailable here, dependency installation (`flutter pub get`), `flutter run`, and build/test cycles were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3fd6705e0832680d3979ff0bdad0e)