### PR TITLE
refactor: run Telegram bot using Webhooks on GCP Cloud Run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   REGION: europe-central2
   SERVICE_NAME: vesta-backend
+  BOT_SERVICE_NAME: vesta-bot
   REPO_NAME: vesta-repo
 
 jobs:
@@ -107,19 +108,22 @@ jobs:
       - name: Configure Docker authentication
         run: |-
           gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+      - name: Set Image Tags
+        run: |
+          echo "IMAGE_TAG=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO_NAME }}/${{ env.SERVICE_NAME }}:${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+          echo "BOT_IMAGE_TAG=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO_NAME }}/${{ env.BOT_SERVICE_NAME }}:${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
-      - name: Set Image Tag
-        run: echo "IMAGE_TAG=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO_NAME }}/${{ env.SERVICE_NAME }}:${GITHUB_SHA::7}" >> "$GITHUB_ENV"
-
-      - name: Build Docker image
+      - name: Build Docker images
         run: |-
           docker build -t ${{ env.IMAGE_TAG }} .
+          docker build -t ${{ env.BOT_IMAGE_TAG }} ./bot
 
-      - name: Push Docker image
+      - name: Push Docker images
         run: |-
           docker push ${{ env.IMAGE_TAG }}
+          docker push ${{ env.BOT_IMAGE_TAG }}
 
-      - name: Deploy to Cloud Run
+      - name: Deploy Backend to Cloud Run
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: ${{ env.SERVICE_NAME }}
@@ -146,3 +150,22 @@ jobs:
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
             GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
             GOOGLE_REDIRECT_URI=${{ secrets.GOOGLE_REDIRECT_URI }}
+
+      - name: Deploy Bot to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.BOT_SERVICE_NAME }}
+          region: ${{ env.REGION }}
+          image: ${{ env.BOT_IMAGE_TAG }}
+          flags: |
+            --max-instances=3
+            --memory=512Mi
+            --cpu=1
+            --allow-unauthenticated
+          env_vars: |-
+            DEBUG=false
+            BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}
+            BACKEND_BASE_URL=${{ secrets.BACKEND_BASE_URL }}
+            BACKEND_API_KEY=${{ secrets.BACKEND_API_KEY }}
+            WEBHOOK_DOMAIN=${{ secrets.BOT_WEBHOOK_DOMAIN }}
+            WEBHOOK_SECRET=${{ secrets.BOT_WEBHOOK_SECRET }}

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.13-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements file
+COPY requirements.txt ./
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . /app/
+
+# Cloud Run sets the PORT environment variable
+ENV PORT 8080
+
+# Run the bot
+CMD ["python", "bot.py"]

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -48,13 +48,29 @@ async def on_startup(bot: Bot, dispatcher: Dispatcher) -> None:
     register_all_handlers()
     register_global_middlewares(dispatcher, config)
     await register_all_commands(bot)
+
+    if not (config.DEBUG or not config.WEBHOOK_DOMAIN):
+        webhook_url = config.WEBHOOK_DOMAIN.rstrip("/") + config.WEBHOOK_PATH
+        secret_token = (
+            config.WEBHOOK_SECRET.get_secret_value()
+            if config.WEBHOOK_SECRET
+            else None
+        )
+        await bot.set_webhook(url=webhook_url, secret_token=secret_token)
+        logging.info(f"Webhook set to: {webhook_url}")
+
     await on_startup_notify(bot)
     logging.info("Bot started.")
 
 
-async def on_shutdown(dispatcher: Dispatcher) -> None:
+async def on_shutdown(bot: Bot, dispatcher: Dispatcher) -> None:
     await dispatcher.storage.close()
     logging.info("Storage closed.")
+
+    if not (config.DEBUG or not config.WEBHOOK_DOMAIN):
+        await bot.delete_webhook(drop_pending_updates=True)
+        logging.info("Webhook deleted.")
+
     logging.info("Bot stopped.")
 
 
@@ -68,10 +84,47 @@ async def main() -> None:
 
     dp.workflow_data.update(user_cache=user_cache)
 
-    # And the run events dispatching
-    await dp.start_polling(bot)
-    # * For the webhook usage:
-    # * https://docs.aiogram.dev/en/dev-3.x/dispatcher/webhook.html#examples
+    if config.DEBUG or not config.WEBHOOK_DOMAIN:
+        logging.info("Starting bot in Long Polling mode...")
+        await dp.start_polling(bot)
+    else:
+        logging.info("Starting bot in Webhook mode...")
+        import os
+        from aiohttp import web
+        from aiogram.webhook.aiohttp_server import (
+            SimpleRequestHandler,
+            setup_application,
+        )
+
+        if not config.WEBHOOK_SECRET:
+            raise ValueError(
+                "WEBHOOK_SECRET must be set when running in Webhook mode."
+            )
+
+        port_env = os.getenv("PORT")
+        port = int(port_env) if port_env else config.APP_PORT
+        host = config.APP_HOST
+
+        app = web.Application()
+
+        webhook_requests_handler = SimpleRequestHandler(
+            dispatcher=dp,
+            bot=bot,
+            secret_token=config.WEBHOOK_SECRET.get_secret_value(),
+        )
+        webhook_requests_handler.register(app, path=config.WEBHOOK_PATH)
+        setup_application(app, dp, bot=bot)
+
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, host=host, port=port)
+        await site.start()
+        logging.info(f"Webhook server running on {host}:{port}")
+
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await runner.cleanup()
 
 
 if __name__ == "__main__":

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,8 +1,15 @@
 import asyncio
 import logging
+import os
+import signal
 
 from aiogram import Bot, Dispatcher
 from aiogram.utils.callback_answer import CallbackAnswerMiddleware
+from aiogram.webhook.aiohttp_server import (
+    SimpleRequestHandler,
+    setup_application,
+)
+from aiohttp import web
 from loader import bot, dp
 from tgbot.config import Settings, config
 from tgbot.infrastructure.logger import setup_logging
@@ -52,9 +59,7 @@ async def on_startup(bot: Bot, dispatcher: Dispatcher) -> None:
     if not (config.DEBUG or not config.WEBHOOK_DOMAIN):
         webhook_url = config.WEBHOOK_DOMAIN.rstrip("/") + config.WEBHOOK_PATH
         secret_token = (
-            config.WEBHOOK_SECRET.get_secret_value()
-            if config.WEBHOOK_SECRET
-            else None
+            config.WEBHOOK_SECRET.get_secret_value() if config.WEBHOOK_SECRET else None
         )
         await bot.set_webhook(url=webhook_url, secret_token=secret_token)
         logging.info(f"Webhook set to: {webhook_url}")
@@ -84,17 +89,9 @@ async def main() -> None:
         await dp.start_polling(bot)
     else:
         logging.info("Starting bot in Webhook mode...")
-        import os
-        from aiohttp import web
-        from aiogram.webhook.aiohttp_server import (
-            SimpleRequestHandler,
-            setup_application,
-        )
 
         if not config.WEBHOOK_SECRET:
-            raise ValueError(
-                "WEBHOOK_SECRET must be set when running in Webhook mode."
-            )
+            raise ValueError("WEBHOOK_SECRET must be set when running in Webhook mode.")
 
         port_env = os.getenv("PORT")
         port = int(port_env) if port_env else config.APP_PORT
@@ -116,7 +113,6 @@ async def main() -> None:
         await site.start()
         logging.info(f"Webhook server running on {host}:{port}")
 
-        import signal
         stop_event = asyncio.Event()
         try:
             loop = asyncio.get_running_loop()

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -66,11 +66,6 @@ async def on_startup(bot: Bot, dispatcher: Dispatcher) -> None:
 async def on_shutdown(bot: Bot, dispatcher: Dispatcher) -> None:
     await dispatcher.storage.close()
     logging.info("Storage closed.")
-
-    if not (config.DEBUG or not config.WEBHOOK_DOMAIN):
-        await bot.delete_webhook(drop_pending_updates=True)
-        logging.info("Webhook deleted.")
-
     logging.info("Bot stopped.")
 
 
@@ -121,8 +116,17 @@ async def main() -> None:
         await site.start()
         logging.info(f"Webhook server running on {host}:{port}")
 
+        import signal
+        stop_event = asyncio.Event()
         try:
-            await asyncio.Event().wait()
+            loop = asyncio.get_running_loop()
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                loop.add_signal_handler(sig, stop_event.set)
+        except NotImplementedError:
+            pass
+
+        try:
+            await stop_event.wait()
         finally:
             await runner.cleanup()
 

--- a/bot/tgbot/config.py
+++ b/bot/tgbot/config.py
@@ -17,6 +17,13 @@ class Settings(BaseSettings):
     GCP_LOG_NAME: str = "vesta-bot"
     GOOGLE_APPLICATION_CREDENTIALS: str = ""
 
+    # Webhook Settings
+    WEBHOOK_DOMAIN: str = ""
+    WEBHOOK_PATH: str = "/webhook"
+    WEBHOOK_SECRET: SecretStr | None = None
+    APP_PORT: int = 8080
+    APP_HOST: str = "0.0.0.0"
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/bot/tgbot/config.py
+++ b/bot/tgbot/config.py
@@ -1,4 +1,4 @@
-from pydantic import SecretStr
+from pydantic import SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -23,6 +23,13 @@ class Settings(BaseSettings):
     WEBHOOK_SECRET: SecretStr | None = None
     APP_PORT: int = 8080
     APP_HOST: str = "0.0.0.0"
+
+    @field_validator("WEBHOOK_PATH")
+    @classmethod
+    def normalize_webhook_path(cls, v: str) -> str:
+        if not v.startswith("/"):
+            v = "/" + v
+        return v.rstrip("/")
 
     model_config = SettingsConfigDict(
         env_file=".env",


### PR DESCRIPTION
Refactors the Vesta Telegram bot to run using **Webhooks** when deployed on **GCP Cloud Run**, with a graceful fallback to **Long Polling** for local development.

### Changes Included:
- **Configuration (`config.py`):** Added settings `WEBHOOK_DOMAIN`, `WEBHOOK_PATH`, `WEBHOOK_SECRET`, `APP_PORT`, and `APP_HOST`.
- **Bot Lifecycle (`bot.py`):** Refactored bot startup and shutdown to register/delete the webhook dynamically when webhook mode is active.
- **Webserver Setup (`bot.py`):** Added aiohttp setup utilizing `SimpleRequestHandler` and `TCPSite`/`AppRunner` to run the webhook server inside the active asyncio loop.
- **Security:** Integrated `secret_token` verification to ensure all incoming requests to the webhook originate from Telegram.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webhook hosting for production deployments, with automatic long-polling fallback for development.
  * Introduced configurable webhook and server settings (domain, path, secret, host, and port) to simplify deployment.
  * Updated deployment to ship a dedicated bot service image to production.

* **Bug Fixes**
  * Improved webhook path handling to ensure consistent formatting (leading “/”, no trailing “/”).

* **Chores**
  * Enhanced startup and shutdown flow for cleaner restarts and graceful server termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->