### PR TITLE
feat(bot): retry backend requests and handle cold start cache load

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -83,10 +83,20 @@ async def main() -> None:
     # Retry cache initialization at startup until it successfully loads from the database
     users_from_db = None
     attempt = 1
+    max_startup_attempts = 12
     while users_from_db is None:
-        logging.info(f"Fetching approved users from database (attempt {attempt})...")
+        logging.info(
+            f"Fetching approved users from database (attempt {attempt}/{max_startup_attempts})..."
+        )
         users_from_db = await user_service.get_approved_users()
         if users_from_db is None:
+            if attempt >= max_startup_attempts:
+                error_msg = (
+                    f"Fatal: Failed to fetch approved users from backend after "
+                    f"{max_startup_attempts} attempts at startup. Exiting."
+                )
+                logging.error(error_msg)
+                raise RuntimeError(error_msg)
             logging.warning("Failed to fetch approved users. Retrying in 5 seconds...")
             await asyncio.sleep(5)
             attempt += 1

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -79,7 +79,18 @@ async def main() -> None:
     dp.shutdown.register(on_shutdown)
 
     user_cache = UserCache()
-    users_from_db = await user_service.get_approved_users()
+
+    # Retry cache initialization at startup until it successfully loads from the database
+    users_from_db = None
+    attempt = 1
+    while users_from_db is None:
+        logging.info(f"Fetching approved users from database (attempt {attempt})...")
+        users_from_db = await user_service.get_approved_users()
+        if users_from_db is None:
+            logging.warning("Failed to fetch approved users. Retrying in 5 seconds...")
+            await asyncio.sleep(5)
+            attempt += 1
+
     user_cache.load(users_from_db)
 
     dp.workflow_data.update(user_cache=user_cache)

--- a/bot/tgbot/handlers/food.py
+++ b/bot/tgbot/handlers/food.py
@@ -36,8 +36,7 @@ async def food_chosen(message: Message, state: FSMContext):
 @router.message(OrderFood.choosing_food_name)
 async def food_chosen_incorrectly(message: Message):
     await message.answer(
-        text="I don't know such a dish.\n\n"
-        "Please, choose from a list above:",
+        text="I don't know such a dish.\n\nPlease, choose from a list above:",
         reply_markup=make_row_keyboard(FOOD_NAMES),
     )
 

--- a/bot/tgbot/handlers/llm.py
+++ b/bot/tgbot/handlers/llm.py
@@ -58,7 +58,11 @@ async def user_message_handler(message: Message, state: FSMContext, user_db_id: 
 
 
 async def _process_llm_request(
-    message: Message, state: FSMContext, user_db_id: int, text: str, want_voice: bool = False
+    message: Message,
+    state: FSMContext,
+    user_db_id: int,
+    text: str,
+    want_voice: bool = False,
 ):
     await state.update_data(message=text)
     data = await state.get_data()

--- a/bot/tgbot/handlers/weather.py
+++ b/bot/tgbot/handlers/weather.py
@@ -16,20 +16,22 @@ async def weather_command(message: Message, command: CommandObject):
         return
 
     args = command.args.split()
-    
+
     days = 1
     last_arg = args[-1]
-    
+
     try:
         days = int(last_arg)
         city_parts = args[:-1]
     except ValueError:
         city_parts = args
-        
+
     if not city_parts:
-        await message.reply("❓ Please provide a city name.\nExample: /weather London 3")
+        await message.reply(
+            "❓ Please provide a city name.\nExample: /weather London 3"
+        )
         return
-        
+
     city_name = " ".join(city_parts)
 
     weather_info = await weather_service.get_forecast(city_name, days=days)

--- a/bot/tgbot/infrastructure/base_service.py
+++ b/bot/tgbot/infrastructure/base_service.py
@@ -30,6 +30,15 @@ class BaseAPIService(ABC):
         self.timeout = ClientTimeout(total=timeout)
         self.api_key = config.backend_api_key.get_secret_value()
         self.logger = logging.getLogger(self.__class__.__name__)
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """
+        Get or create a reusable aiohttp ClientSession.
+        """
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
 
     def _get_headers(self, custom_headers: dict | None = None) -> dict:
         """
@@ -54,7 +63,7 @@ class BaseAPIService(ABC):
         json_data: dict | None = None,
         headers: dict | None = None,
         timeout: int | None = None,
-        max_retries: int = 5,
+        max_retries: int | None = None,
         backoff_factor: float = 1.5,
         initial_delay: float = 1.0,
     ) -> tuple[int, dict | None]:
@@ -68,7 +77,7 @@ class BaseAPIService(ABC):
             json_data: JSON payload.
             headers: Optional custom headers.
             timeout: Request timeout in seconds.
-            max_retries: Maximum number of retries.
+            max_retries: Maximum number of retries. Defaults to 5 for GET and 1 for others.
             backoff_factor: Multiplier for retry delay.
             initial_delay: Starting delay in seconds.
 
@@ -76,42 +85,46 @@ class BaseAPIService(ABC):
             Tuple of (status_code, response_data).
             Returns (0, None) if connection fails.
         """
+        if max_retries is None:
+            max_retries = 5 if method == "GET" else 1
+
         url = f"{self.base_url}{self.API_PREFIX}{endpoint}"
         request_headers = self._get_headers(headers)
         request_timeout = ClientTimeout(total=timeout) if timeout else self.timeout
 
+        session = await self._get_session()
         delay = initial_delay
         for attempt in range(1, max_retries + 1):
             try:
-                async with aiohttp.ClientSession(timeout=request_timeout) as session:
-                    async with session.request(
-                        method,
-                        url,
-                        params=params,
-                        json=json_data,
-                        headers=request_headers,
-                    ) as response:
-                        status = response.status
+                async with session.request(
+                    method,
+                    url,
+                    params=params,
+                    json=json_data,
+                    headers=request_headers,
+                    timeout=request_timeout,
+                ) as response:
+                    status = response.status
 
-                        if response.content_type == "application/json":
-                            data = await response.json()
-                        else:
-                            data = {"detail": await response.text()}
+                    if response.content_type == "application/json":
+                        data = await response.json()
+                    else:
+                        data = {"detail": await response.text()}
 
-                        self.logger.debug(f"{method} {url} - Status: {status}")
+                    self.logger.debug(f"{method} {url} - Status: {status}")
 
-                        # Retry on 5xx server errors
-                        if status >= 500:
-                            if attempt == max_retries:
-                                self.logger.error(
-                                    f"Request {method} {url} failed with status {status} after {max_retries} attempts."
-                                )
-                                return status, data
-                            self.logger.warning(
-                                f"Attempt {attempt} for {method} {url} returned status {status}. Retrying in {delay}s..."
+                    # Retry on 5xx server errors
+                    if status >= 500:
+                        if attempt == max_retries:
+                            self.logger.error(
+                                f"Request {method} {url} failed with status {status} after {max_retries} attempts."
                             )
-                        else:
                             return status, data
+                        self.logger.warning(
+                            f"Attempt {attempt} for {method} {url} returned status {status}. Retrying in {delay}s..."
+                        )
+                    else:
+                        return status, data
 
             except asyncio.TimeoutError:
                 if attempt == max_retries:
@@ -148,12 +161,18 @@ class BaseAPIService(ABC):
         params: dict | None = None,
         headers: dict | None = None,
         timeout: int | None = None,
+        max_retries: int | None = None,
     ) -> tuple[int, dict | None]:
         """
         Make a GET request to the backend API with retries.
         """
         return await self._request(
-            "GET", endpoint, params=params, headers=headers, timeout=timeout
+            "GET",
+            endpoint,
+            params=params,
+            headers=headers,
+            timeout=timeout,
+            max_retries=max_retries,
         )
 
     async def _post(
@@ -162,12 +181,18 @@ class BaseAPIService(ABC):
         json_data: dict | None = None,
         headers: dict | None = None,
         timeout: int | None = None,
+        max_retries: int | None = None,
     ) -> tuple[int, dict | None]:
         """
         Make a POST request to the backend API with retries.
         """
         return await self._request(
-            "POST", endpoint, json_data=json_data, headers=headers, timeout=timeout
+            "POST",
+            endpoint,
+            json_data=json_data,
+            headers=headers,
+            timeout=timeout,
+            max_retries=max_retries,
         )
 
     async def _put(
@@ -176,12 +201,18 @@ class BaseAPIService(ABC):
         json_data: dict | None = None,
         headers: dict | None = None,
         timeout: int | None = None,
+        max_retries: int | None = None,
     ) -> tuple[int, dict | None]:
         """
         Make a PUT request to the backend API with retries.
         """
         return await self._request(
-            "PUT", endpoint, json_data=json_data, headers=headers, timeout=timeout
+            "PUT",
+            endpoint,
+            json_data=json_data,
+            headers=headers,
+            timeout=timeout,
+            max_retries=max_retries,
         )
 
     async def _patch(
@@ -190,21 +221,37 @@ class BaseAPIService(ABC):
         json_data: dict | None = None,
         headers: dict | None = None,
         timeout: int | None = None,
+        max_retries: int | None = None,
     ) -> tuple[int, dict | None]:
         """
         Make a PATCH request to the backend API with retries.
         """
         return await self._request(
-            "PATCH", endpoint, json_data=json_data, headers=headers, timeout=timeout
+            "PATCH",
+            endpoint,
+            json_data=json_data,
+            headers=headers,
+            timeout=timeout,
+            max_retries=max_retries,
         )
 
     async def _delete(
-        self, endpoint: str, headers: dict | None = None, timeout: int | None = None
+        self,
+        endpoint: str,
+        headers: dict | None = None,
+        timeout: int | None = None,
+        max_retries: int | None = None,
     ) -> tuple[int, dict | None]:
         """
         Make a DELETE request to the backend API with retries.
         """
-        return await self._request("DELETE", endpoint, headers=headers, timeout=timeout)
+        return await self._request(
+            "DELETE",
+            endpoint,
+            headers=headers,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
 
     def _handle_error_response(
         self, status: int, data: dict | None, context: str

--- a/bot/tgbot/infrastructure/base_service.py
+++ b/bot/tgbot/infrastructure/base_service.py
@@ -46,20 +46,31 @@ class BaseAPIService(ABC):
             headers.update(custom_headers)
         return headers
 
-    async def _get(
+    async def _request(
         self,
+        method: str,
         endpoint: str,
         params: dict | None = None,
+        json_data: dict | None = None,
         headers: dict | None = None,
         timeout: int | None = None,
+        max_retries: int = 5,
+        backoff_factor: float = 1.5,
+        initial_delay: float = 1.0,
     ) -> tuple[int, dict | None]:
         """
-        Make a GET request to the backend API.
+        Make an HTTP request with exponential backoff retries.
 
         Args:
-            endpoint: API endpoint path (e.g., "/weather/current").
+            method: HTTP method (GET, POST, PUT, PATCH, DELETE).
+            endpoint: API endpoint path.
             params: Query parameters.
-            headers: Optional custom headers to include in the request.
+            json_data: JSON payload.
+            headers: Optional custom headers.
+            timeout: Request timeout in seconds.
+            max_retries: Maximum number of retries.
+            backoff_factor: Multiplier for retry delay.
+            initial_delay: Starting delay in seconds.
 
         Returns:
             Tuple of (status_code, response_data).
@@ -69,30 +80,81 @@ class BaseAPIService(ABC):
         request_headers = self._get_headers(headers)
         request_timeout = ClientTimeout(total=timeout) if timeout else self.timeout
 
-        try:
-            async with aiohttp.ClientSession(timeout=request_timeout) as session:
-                async with session.get(
-                    url, params=params, headers=request_headers
-                ) as response:
-                    status = response.status
+        delay = initial_delay
+        for attempt in range(1, max_retries + 1):
+            try:
+                async with aiohttp.ClientSession(timeout=request_timeout) as session:
+                    async with session.request(
+                        method,
+                        url,
+                        params=params,
+                        json=json_data,
+                        headers=request_headers,
+                    ) as response:
+                        status = response.status
 
-                    if response.content_type == "application/json":
-                        data = await response.json()
-                    else:
-                        data = {"detail": await response.text()}
+                        if response.content_type == "application/json":
+                            data = await response.json()
+                        else:
+                            data = {"detail": await response.text()}
 
-                    self.logger.debug(f"GET {url} - Status: {status}")
-                    return status, data
+                        self.logger.debug(f"{method} {url} - Status: {status}")
 
-        except asyncio.TimeoutError:
-            self.logger.error(f"Timeout error during GET request to {url}")
-            return 0, None
-        except ClientError as e:
-            self.logger.error(f"Connection error to {url}: {e}")
-            return 0, None
-        except Exception as e:
-            self.logger.error(f"Unexpected error during GET request to {url}: {e}")
-            return 0, None
+                        # Retry on 5xx server errors
+                        if status >= 500:
+                            if attempt == max_retries:
+                                self.logger.error(
+                                    f"Request {method} {url} failed with status {status} after {max_retries} attempts."
+                                )
+                                return status, data
+                            self.logger.warning(
+                                f"Attempt {attempt} for {method} {url} returned status {status}. Retrying in {delay}s..."
+                            )
+                        else:
+                            return status, data
+
+            except asyncio.TimeoutError:
+                if attempt == max_retries:
+                    self.logger.error(
+                        f"Timeout error during {method} request to {url} after {max_retries} attempts."
+                    )
+                    return 0, None
+                self.logger.warning(
+                    f"Attempt {attempt} for {method} {url} timed out. Retrying in {delay}s..."
+                )
+            except ClientError as e:
+                if attempt == max_retries:
+                    self.logger.error(
+                        f"Connection error to {url} after {max_retries} attempts: {e}"
+                    )
+                    return 0, None
+                self.logger.warning(
+                    f"Attempt {attempt} for {method} {url} failed with connection error: {e}. Retrying in {delay}s..."
+                )
+            except Exception as e:
+                self.logger.error(
+                    f"Unexpected error during {method} request to {url}: {e}"
+                )
+                return 0, None
+
+            await asyncio.sleep(delay)
+            delay *= backoff_factor
+
+        return 0, None
+
+    async def _get(
+        self,
+        endpoint: str,
+        params: dict | None = None,
+        headers: dict | None = None,
+        timeout: int | None = None,
+    ) -> tuple[int, dict | None]:
+        """
+        Make a GET request to the backend API with retries.
+        """
+        return await self._request(
+            "GET", endpoint, params=params, headers=headers, timeout=timeout
+        )
 
     async def _post(
         self,
@@ -102,45 +164,11 @@ class BaseAPIService(ABC):
         timeout: int | None = None,
     ) -> tuple[int, dict | None]:
         """
-        Make a POST request to the backend API.
-
-        Args:
-            endpoint: API endpoint path.
-            json_data: JSON payload.
-            headers: Optional custom headers to include in the request.
-
-        Returns:
-            Tuple of (status_code, response_data).
-            Returns (0, None) if connection fails.
+        Make a POST request to the backend API with retries.
         """
-        url = f"{self.base_url}{self.API_PREFIX}{endpoint}"
-        request_headers = self._get_headers(headers)
-        request_timeout = ClientTimeout(total=timeout) if timeout else self.timeout
-
-        try:
-            async with aiohttp.ClientSession(timeout=request_timeout) as session:
-                async with session.post(
-                    url, json=json_data, headers=request_headers
-                ) as response:
-                    status = response.status
-
-                    if response.content_type == "application/json":
-                        data = await response.json()
-                    else:
-                        data = {"detail": await response.text()}
-
-                    self.logger.debug(f"POST {url} - Status: {status}")
-                    return status, data
-
-        except asyncio.TimeoutError:
-            self.logger.error(f"Timeout error during POST request to {url}")
-            return 0, None
-        except ClientError as e:
-            self.logger.error(f"Connection error to {url}: {e}")
-            return 0, None
-        except Exception as e:
-            self.logger.error(f"Unexpected error during POST request to {url}: {e}")
-            return 0, None
+        return await self._request(
+            "POST", endpoint, json_data=json_data, headers=headers, timeout=timeout
+        )
 
     async def _put(
         self,
@@ -150,45 +178,11 @@ class BaseAPIService(ABC):
         timeout: int | None = None,
     ) -> tuple[int, dict | None]:
         """
-        Make a PUT request to the backend API.
-
-        Args:
-            endpoint: API endpoint path.
-            json_data: JSON payload.
-            headers: Optional custom headers to include in the request.
-
-        Returns:
-            Tuple of (status_code, response_data).
-            Returns (0, None) if connection fails.
+        Make a PUT request to the backend API with retries.
         """
-        url = f"{self.base_url}{self.API_PREFIX}{endpoint}"
-        request_headers = self._get_headers(headers)
-        request_timeout = ClientTimeout(total=timeout) if timeout else self.timeout
-
-        try:
-            async with aiohttp.ClientSession(timeout=request_timeout) as session:
-                async with session.put(
-                    url, json=json_data, headers=request_headers
-                ) as response:
-                    status = response.status
-
-                    if response.content_type == "application/json":
-                        data = await response.json()
-                    else:
-                        data = {"detail": await response.text()}
-
-                    self.logger.debug(f"PUT {url} - Status: {status}")
-                    return status, data
-
-        except asyncio.TimeoutError:
-            self.logger.error(f"Timeout error during PUT request to {url}")
-            return 0, None
-        except ClientError as e:
-            self.logger.error(f"Connection error to {url}: {e}")
-            return 0, None
-        except Exception as e:
-            self.logger.error(f"Unexpected error during PUT request to {url}: {e}")
-            return 0, None
+        return await self._request(
+            "PUT", endpoint, json_data=json_data, headers=headers, timeout=timeout
+        )
 
     async def _patch(
         self,
@@ -198,86 +192,19 @@ class BaseAPIService(ABC):
         timeout: int | None = None,
     ) -> tuple[int, dict | None]:
         """
-        Make a PATCH request to the backend API.
-
-        Args:
-            endpoint: API endpoint path.
-            json_data: JSON payload.
-            headers: Optional custom headers to include in the request.
-
-        Returns:
-            Tuple of (status_code, response_data).
-            Returns (0, None) if connection fails.
+        Make a PATCH request to the backend API with retries.
         """
-        url = f"{self.base_url}{self.API_PREFIX}{endpoint}"
-        request_headers = self._get_headers(headers)
-        request_timeout = ClientTimeout(total=timeout) if timeout else self.timeout
-
-        try:
-            async with aiohttp.ClientSession(timeout=request_timeout) as session:
-                async with session.patch(
-                    url, json=json_data, headers=request_headers
-                ) as response:
-                    status = response.status
-
-                    if response.content_type == "application/json":
-                        data = await response.json()
-                    else:
-                        data = {"detail": await response.text()}
-
-                    self.logger.debug(f"PATCH {url} - Status: {status}")
-                    return status, data
-
-        except asyncio.TimeoutError:
-            self.logger.error(f"Timeout error during PATCH request to {url}")
-            return 0, None
-        except ClientError as e:
-            self.logger.error(f"Connection error to {url}: {e}")
-            return 0, None
-        except Exception as e:
-            self.logger.error(f"Unexpected error during PATCH request to {url}: {e}")
-            return 0, None
+        return await self._request(
+            "PATCH", endpoint, json_data=json_data, headers=headers, timeout=timeout
+        )
 
     async def _delete(
         self, endpoint: str, headers: dict | None = None, timeout: int | None = None
     ) -> tuple[int, dict | None]:
         """
-        Make a DELETE request to the backend API.
-
-        Args:
-            endpoint: API endpoint path.
-            headers: Optional custom headers to include in the request.
-
-        Returns:
-            Tuple of (status_code, response_data).
-            Returns (0, None) if connection fails.
+        Make a DELETE request to the backend API with retries.
         """
-        url = f"{self.base_url}{self.API_PREFIX}{endpoint}"
-        request_headers = self._get_headers(headers)
-        request_timeout = ClientTimeout(total=timeout) if timeout else self.timeout
-
-        try:
-            async with aiohttp.ClientSession(timeout=request_timeout) as session:
-                async with session.delete(url, headers=request_headers) as response:
-                    status = response.status
-
-                    if response.content_type == "application/json":
-                        data = await response.json()
-                    else:
-                        data = {"detail": await response.text()}
-
-                    self.logger.debug(f"DELETE {url} - Status: {status}")
-                    return status, data
-
-        except asyncio.TimeoutError:
-            self.logger.error(f"Timeout error during DELETE request to {url}")
-            return 0, None
-        except ClientError as e:
-            self.logger.error(f"Connection error to {url}: {e}")
-            return 0, None
-        except Exception as e:
-            self.logger.error(f"Unexpected error during DELETE request to {url}: {e}")
-            return 0, None
+        return await self._request("DELETE", endpoint, headers=headers, timeout=timeout)
 
     def _handle_error_response(
         self, status: int, data: dict | None, context: str
@@ -304,15 +231,11 @@ class BaseAPIService(ABC):
             self.logger.warning(f"Bad request while {context}: {error_msg}")
             return "❌ Invalid request. Please try again."
         elif status == 401:
-            error_msg = (
-                data.get("detail", "Unauthorized") if data else "Unauthorized"
-            )
+            error_msg = data.get("detail", "Unauthorized") if data else "Unauthorized"
             self.logger.warning(f"Unauthorized while {context}: {error_msg}")
             return f"❌ Unauthorized: {error_msg}"
         elif status == 403:
-            error_msg = (
-                data.get("detail", "Forbidden") if data else "Forbidden"
-            )
+            error_msg = data.get("detail", "Forbidden") if data else "Forbidden"
             self.logger.warning(f"Forbidden while {context}: {error_msg}")
             return f"❌ Forbidden: {error_msg}"
         elif status == 500:

--- a/bot/tgbot/infrastructure/llm_service.py
+++ b/bot/tgbot/infrastructure/llm_service.py
@@ -25,9 +25,14 @@ class LLMService(BaseAPIService):
         endpoint = "/chat/process"
 
         status, data = await self._post(
-            endpoint, 
-            {"user_id": user_id, "session_id": session_id, "message": prompt, "want_voice": want_voice},
-            timeout=60
+            endpoint,
+            {
+                "user_id": user_id,
+                "session_id": session_id,
+                "message": prompt,
+                "want_voice": want_voice,
+            },
+            timeout=60,
         )
 
         if status == 200:

--- a/bot/tgbot/infrastructure/user_service.py
+++ b/bot/tgbot/infrastructure/user_service.py
@@ -14,7 +14,7 @@ class UserService(BaseAPIService):
         """
         super().__init__(base_url, timeout)
 
-    async def get_approved_users(self) -> list[int]:
+    async def get_approved_users(self) -> list[dict] | None:
         """
         Get list of approved users.
         """
@@ -25,7 +25,7 @@ class UserService(BaseAPIService):
         if status == 200:
             return data
         else:
-            return []
+            return None
 
     async def enable_daily_summary(self, user_id: int) -> tuple[dict | None, str]:
         """

--- a/bot/tgbot/keyboards/inline/help_keyboard.py
+++ b/bot/tgbot/keyboards/inline/help_keyboard.py
@@ -8,8 +8,7 @@ def create_markup() -> InlineKeyboardMarkup:
             [
                 InlineKeyboardButton(
                     text="Посилання на сайт",
-                    url="https://mezgoodle.github.io/TelegramiaSite/telegramia"
-                    "/#manual",
+                    url="https://mezgoodle.github.io/TelegramiaSite/telegramia/#manual",
                 )
             ]
         ],

--- a/bot/tgbot/services/stt.py
+++ b/bot/tgbot/services/stt.py
@@ -34,9 +34,8 @@ class GoogleSTTService:
 
         self.location_code = "us"
         credentials = None
-        if (
+        if config.GOOGLE_APPLICATION_CREDENTIALS and os.path.exists(
             config.GOOGLE_APPLICATION_CREDENTIALS
-            and os.path.exists(config.GOOGLE_APPLICATION_CREDENTIALS)
         ):
             credentials = service_account.Credentials.from_service_account_file(
                 config.GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
This PR implements retries with exponential backoff for requests from the Telegram bot to the backend, addressing issues with Cloud Run cold starts on free tier. Additionally, it ensures that the approved users cache is successfully fetched and loaded at startup by loop-retrying on connection/timeout or 5xx failures.

### Changes:
- **Base Service (`base_service.py`):** Added a central async `_request` method that handles exponential backoff retries (up to 5 attempts, backoff factor 1.5, starting at 1.0s delay) for all HTTP methods (GET, POST, PUT, PATCH, DELETE) when encountering connection, timeout, or 5xx server errors.
- **User Service (`user_service.py`):** Refactored `get_approved_users` to return `None` (instead of an empty list `[]`) on failed requests to help distinguish failure from a successful but empty response. Updated type hints accordingly.
- **Bot Startup (`bot.py`):** Updated the startup sequence to block/loop-retry fetching approved users from the backend until it successfully loads, preventing the bot from cache-initializing with an empty list and blocking everyone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved startup reliability by repeatedly checking for approved users before finishing initialization.

* **Bug Fixes**
  * Backend requests now retry automatically on temporary failures and timeouts, making bot actions more resilient.
  * Approved-user loading now handles service interruptions more gracefully instead of failing fast.
  * Minor text and formatting updates were applied to weather, food, and help responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->