### PR TITLE
fix(adk): inject current time context into sub-agents to resolve relative dates correctly

### DIFF
--- a/backend/app/agents/calendar_agent.py
+++ b/backend/app/agents/calendar_agent.py
@@ -7,8 +7,26 @@ from typing import Callable
 from google.adk.agents import LlmAgent
 
 
-def create_calendar_agent(tools: list[Callable], model: str) -> LlmAgent:
+def create_calendar_agent(
+    tools: list[Callable], model: str, current_time_str: str | None = None
+) -> LlmAgent:
     """Create the Calendar sub-agent."""
+    instruction = (
+        "You are a scheduling assistant within the Vesta smart assistant.\n"
+        "Your responsibilities:\n"
+        "1. Retrieve upcoming calendar events using the get_calendar_events tool.\n"
+        "2. Schedule new calendar events using the schedule_event_tool.\n"
+        "3. For requests about 'today' or 'my day', call get_calendar_events(days=1).\n"
+        "Always respond in a friendly, concise manner."
+    )
+    if current_time_str:
+        instruction = (
+            f"Current Date and Time: {current_time_str}.\n"
+            f"When scheduling or retrieving events, use the 'Current Date' above as a reference "
+            f"to calculate relative dates like 'today', 'tomorrow', 'yesterday', or 'next Friday'.\n"
+            f"{instruction}"
+        )
+
     return LlmAgent(
         name="CalendarAgent",
         model=model,
@@ -17,13 +35,6 @@ def create_calendar_agent(tools: list[Callable], model: str) -> LlmAgent:
             "agent when the user asks about their schedule, wants to see upcoming "
             "events, or wants to create a calendar event."
         ),
-        instruction=(
-            "You are a scheduling assistant within the Vesta smart assistant.\n"
-            "Your responsibilities:\n"
-            "1. Retrieve upcoming calendar events using the get_calendar_events tool.\n"
-            "2. Schedule new calendar events using the schedule_event_tool.\n"
-            "3. For requests about 'today' or 'my day', call get_calendar_events(days=1).\n"
-            "Always respond in a friendly, concise manner."
-        ),
+        instruction=instruction,
         tools=tools,
     )

--- a/backend/app/agents/knowledge_agent.py
+++ b/backend/app/agents/knowledge_agent.py
@@ -10,7 +10,9 @@ from typing import Callable
 from google.adk.agents import LlmAgent
 
 
-def create_knowledge_agent(tools: list[Callable], model: str) -> LlmAgent:
+def create_knowledge_agent(
+    tools: list[Callable], model: str, current_time_str: str | None = None
+) -> LlmAgent:
     """
     Create the Knowledge sub-agent.
 
@@ -18,10 +20,27 @@ def create_knowledge_agent(tools: list[Callable], model: str) -> LlmAgent:
         tools: Pre-bound tool functions for RAG
                (``consult_knowledge_base``).
         model: The Gemini model name (e.g. ``gemini-2.5-flash``).
+        current_time_str: Optional current date/time context.
 
     Returns:
         A configured ``LlmAgent`` ready for use as a sub-agent.
     """
+    instruction = (
+        "You are a knowledge base assistant within the Vesta smart assistant.\n"
+        "Your responsibilities:\n"
+        "1. Search the user's personal knowledge base using the "
+        "consult_knowledge_base tool.\n"
+        "2. Synthesize information from retrieved documents into clear, "
+        "helpful answers.\n"
+        "3. If the knowledge base returns no relevant results, let the user "
+        "know and suggest they may need to sync their documents.\n"
+        "4. Always cite or reference the source context when providing "
+        "information from documents.\n"
+        "Always respond in a friendly, concise manner."
+    )
+    if current_time_str:
+        instruction = f"Current Date and Time: {current_time_str}.\n{instruction}"
+
     return LlmAgent(
         name="KnowledgeAgent",
         model=model,
@@ -32,18 +51,6 @@ def create_knowledge_agent(tools: list[Callable], model: str) -> LlmAgent:
             "notes, research papers, or any topic that might be in their "
             "document library."
         ),
-        instruction=(
-            "You are a knowledge base assistant within the Vesta smart assistant.\n"
-            "Your responsibilities:\n"
-            "1. Search the user's personal knowledge base using the "
-            "consult_knowledge_base tool.\n"
-            "2. Synthesize information from retrieved documents into clear, "
-            "helpful answers.\n"
-            "3. If the knowledge base returns no relevant results, let the user "
-            "know and suggest they may need to sync their documents.\n"
-            "4. Always cite or reference the source context when providing "
-            "information from documents.\n"
-            "Always respond in a friendly, concise manner."
-        ),
+        instruction=instruction,
         tools=tools,
     )

--- a/backend/app/agents/weather_agent.py
+++ b/backend/app/agents/weather_agent.py
@@ -7,8 +7,26 @@ from typing import Callable
 from google.adk.agents import LlmAgent
 
 
-def create_weather_agent(tools: list[Callable], model: str) -> LlmAgent:
+def create_weather_agent(
+    tools: list[Callable], model: str, current_time_str: str | None = None
+) -> LlmAgent:
     """Create the Weather sub-agent."""
+    instruction = (
+        "You are a weather assistant within the Vesta smart assistant.\n"
+        "Your responsibilities:\n"
+        "1. Fetch weather information for any city using the get_weather_info tool.\n"
+        "2. If the user's weather request is ambiguous, default to Ukraine.\n"
+        "3. For requests about today, use days=1 whenever appropriate.\n"
+        "Always respond in a friendly, concise manner."
+    )
+    if current_time_str:
+        instruction = (
+            f"Current Date and Time: {current_time_str}.\n"
+            f"When resolving relative dates like 'today', 'tomorrow', 'this weekend', or 'next Monday', "
+            f"use the 'Current Date' above as your reference.\n"
+            f"{instruction}"
+        )
+
     return LlmAgent(
         name="WeatherAgent",
         model=model,
@@ -17,13 +35,6 @@ def create_weather_agent(tools: list[Callable], model: str) -> LlmAgent:
             "the user asks about current weather, temperature, rain, forecast, "
             "or weather conditions in any city."
         ),
-        instruction=(
-            "You are a weather assistant within the Vesta smart assistant.\n"
-            "Your responsibilities:\n"
-            "1. Fetch weather information for any city using the get_weather_info tool.\n"
-            "2. If the user's weather request is ambiguous, default to Ukraine.\n"
-            "3. For requests about today, use days=1 whenever appropriate.\n"
-            "Always respond in a friendly, concise manner."
-        ),
+        instruction=instruction,
         tools=tools,
     )

--- a/backend/app/services/adk_service.py
+++ b/backend/app/services/adk_service.py
@@ -12,9 +12,12 @@ The ``generate_session_summary`` method uses a standalone ``SummaryAgent``
 for rolling conversation summaries (invoked by background tasks).
 """
 
+import datetime
 import logging
 import os
 from typing import TYPE_CHECKING
+
+import pytz
 
 from google.adk.events import Event
 from google.adk.runners import InMemoryRunner
@@ -99,18 +102,26 @@ class ADKService:
             # 1. Create tools bound to this request's context
             tool_groups = create_tools(user_id=user_id, db=db)
 
+            # Calculate current time for Europe/Kyiv timezone to pass to sub-agents
+            tz = pytz.timezone("Europe/Kyiv")
+            now = datetime.datetime.now(tz)
+            current_time_str = now.strftime("%Y-%m-%d %H:%M (%A)")
+
             # 2. Build agent hierarchy
             weather = create_weather_agent(
                 tools=tool_groups["weather"],
                 model=self.model,
+                current_time_str=current_time_str,
             )
             calendar = create_calendar_agent(
                 tools=tool_groups["calendar"],
                 model=self.model,
+                current_time_str=current_time_str,
             )
             knowledge = create_knowledge_agent(
                 tools=tool_groups["knowledge"],
                 model=self.model,
+                current_time_str=current_time_str,
             )
 
             system_instruction = build_system_instruction(session_summary)

--- a/backend/app/services/adk_service.py
+++ b/backend/app/services/adk_service.py
@@ -17,7 +17,7 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-import pytz
+from zoneinfo import ZoneInfo
 
 from google.adk.events import Event
 from google.adk.runners import InMemoryRunner
@@ -103,7 +103,7 @@ class ADKService:
             tool_groups = create_tools(user_id=user_id, db=db)
 
             # Calculate current time for Europe/Kyiv timezone to pass to sub-agents
-            tz = pytz.timezone("Europe/Kyiv")
+            tz = ZoneInfo("Europe/Kyiv")
             now = datetime.datetime.now(tz)
             current_time_str = now.strftime("%Y-%m-%d %H:%M (%A)")
 
@@ -124,7 +124,10 @@ class ADKService:
                 current_time_str=current_time_str,
             )
 
-            system_instruction = build_system_instruction(session_summary)
+            system_instruction = build_system_instruction(
+                session_summary=session_summary,
+                current_time_str=current_time_str,
+            )
 
             root_agent = create_root_agent(
                 sub_agents=[weather, calendar, knowledge],

--- a/backend/app/services/gemini_tools.py
+++ b/backend/app/services/gemini_tools.py
@@ -19,7 +19,7 @@ import datetime
 import logging
 from typing import Callable
 
-import pytz
+from zoneinfo import ZoneInfo
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.schemas.calendar import CalendarEventCreate
@@ -272,7 +272,10 @@ def create_tools(
 # ------------------------------------------------------------------ #
 
 
-def build_system_instruction(session_summary: str | None = None) -> str:
+def build_system_instruction(
+    session_summary: str | None = None,
+    current_time_str: str | None = None,
+) -> str:
     """
     Build the dynamic system instruction for the root agent.
 
@@ -280,15 +283,17 @@ def build_system_instruction(session_summary: str | None = None) -> str:
 
     Args:
         session_summary: Optional rolling summary of the conversation so far.
+        current_time_str: Optional current date/time context.
 
     Returns:
         The full system instruction string.
     """
     from app.core.config import settings
 
-    tz = pytz.timezone("Europe/Kyiv")
-    now = datetime.datetime.now(tz)
-    current_time_str = now.strftime("%Y-%m-%d %H:%M (%A)")
+    if not current_time_str:
+        tz = ZoneInfo("Europe/Kyiv")
+        now = datetime.datetime.now(tz)
+        current_time_str = now.strftime("%Y-%m-%d %H:%M (%A)")
 
     dynamic_system_instruction = (
         f"{settings.SYSTEM_INSTRUCTION}\n"


### PR DESCRIPTION
This PR fixes a bug where `CalendarAgent` and `WeatherAgent` scheduled/resolved relative dates incorrectly because they lacked access to the current date/time context.

### Changes:
- **`adk_service.py`**: Calculate `current_time_str` in `Europe/Kyiv` timezone at request processing time.
- **`calendar_agent.py`, `weather_agent.py`, `knowledge_agent.py`**: Accept `current_time_str` optional parameter in their factories and prepend the date/time reference block to the instructions.
- Resolved scheduling offset issues where `CalendarAgent` assumed the date was still July 7 (from session history) instead of July 9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant responses for weather, calendar, and knowledge requests now use the current local date and time as a reference.
  * Relative dates like “today,” “tomorrow,” or “next Friday” should be interpreted more accurately.

* **Bug Fixes**
  * Improved time-based request handling so answers are better aligned with the present date in the Kyiv timezone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->