### PR TITLE
Improve morning digest: fetch recent emails and full weather forecast

### DIFF
--- a/backend/app/api/v1/endpoints/cron.py
+++ b/backend/app/api/v1/endpoints/cron.py
@@ -10,12 +10,12 @@ from app.api.deps import SessionDep, verify_cron_secret
 from app.core.config import settings
 from app.models.device import SmartDevice
 from app.models.user import User
-from app.schemas.weather import WeatherData
+from app.schemas.open_meteo import OpenMeteoResponse
 from app.services.gmail_service import gmail_service_instance
 from app.services.google_calendar import google_calendar_service_instance
 from app.services.home import HomeAssistantService
 from app.services.llm import LLMService
-from app.services.weather import weather_service_instance
+from app.services.open_meteo_service import open_meteo_service_instance
 
 logger = logging.getLogger(__name__)
 
@@ -57,16 +57,14 @@ async def send_daily_digests(db: AsyncSession) -> int:
                 )
                 events = []
 
-            weather: WeatherData = (
-                await weather_service_instance.get_current_weather_by_city_name(
-                    user.city_name or "Kyiv"
-                )
+            weather: OpenMeteoResponse = await open_meteo_service_instance.get_weather(
+                city=user.city_name or "Kyiv", days=1
             )
 
             emails = None
             try:
                 emails = await gmail_service_instance.get_emails(
-                    user_id=user.id, db=db, query="is:unread", max_results=5
+                    user_id=user.id, db=db, query="newer_than:1d", max_results=5
                 )
             except Exception as e:
                 logger.warning(
@@ -82,16 +80,25 @@ async def send_daily_digests(db: AsyncSession) -> int:
                 )
             else:
                 events_text = "Сьогодні немає запланованих подій у календарі."
-            weather_text = f"Погода в місті {weather.city}: {weather.temp}°C, {weather.description}"
+            weather_text = (
+                f"Погода в місті {weather.city_name}: "
+                f"зараз {weather.current_temp}°C, {weather.current_conditions}."
+            )
+            if weather.daily_forecasts:
+                today = weather.daily_forecasts[0]
+                weather_text += (
+                    f" Прогноз на сьогодні: макс {today.max_temp}°C, мін {today.min_temp}°C, "
+                    f"ймовірність опадів {today.precipitation_prob_max}%."
+                )
 
             if emails is None:
-                emails_text = "Не вдалося перевірити непрочитані листи."
+                emails_text = "Не вдалося перевірити пошту."
             elif emails:
-                emails_text = "Непрочитані листи:\n" + "\n".join(
+                emails_text = "Останні листи за добу:\n" + "\n".join(
                     [f"- від {e.sender}: {e.subject}" for e in emails]
                 )
             else:
-                emails_text = "Непрочитаних листів немає."
+                emails_text = "За останню добу нових листів не було."
 
             prompt = (
                 f"Ось мій розклад на сьогодні:\n{events_text}\n\n"

--- a/backend/app/api/v1/endpoints/cron.py
+++ b/backend/app/api/v1/endpoints/cron.py
@@ -57,9 +57,15 @@ async def send_daily_digests(db: AsyncSession) -> int:
                 )
                 events = []
 
-            weather: OpenMeteoResponse = await open_meteo_service_instance.get_weather(
-                city=user.city_name or "Kyiv", days=1
-            )
+            weather: OpenMeteoResponse | None = None
+            try:
+                weather = await open_meteo_service_instance.get_weather(
+                    city=user.city_name or "Kyiv", days=1
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to fetch weather for user {user.id}: {e}"
+                )
 
             emails = None
             try:
@@ -80,16 +86,20 @@ async def send_daily_digests(db: AsyncSession) -> int:
                 )
             else:
                 events_text = "Сьогодні немає запланованих подій у календарі."
-            weather_text = (
-                f"Погода в місті {weather.city_name}: "
-                f"зараз {weather.current_temp}°C, {weather.current_conditions}."
-            )
-            if weather.daily_forecasts:
-                today = weather.daily_forecasts[0]
-                weather_text += (
-                    f" Прогноз на сьогодні: макс {today.max_temp}°C, мін {today.min_temp}°C, "
-                    f"ймовірність опадів {today.precipitation_prob_max}%."
+
+            if weather:
+                weather_text = (
+                    f"Погода в місті {weather.city_name}: "
+                    f"зараз {weather.current_temp}°C, {weather.current_conditions}."
                 )
+                if weather.daily_forecasts:
+                    today = weather.daily_forecasts[0]
+                    weather_text += (
+                        f" Прогноз на сьогодні: макс {today.max_temp}°C, мін {today.min_temp}°C, "
+                        f"ймовірність опадів {today.precipitation_prob_max}%."
+                    )
+            else:
+                weather_text = "Не вдалося отримати дані про погоду."
 
             if emails is None:
                 emails_text = "Не вдалося перевірити пошту."

--- a/backend/tests/api/test_cron.py
+++ b/backend/tests/api/test_cron.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.models.user import User
 from app.models.device import SmartDevice
-from app.schemas.weather import WeatherData
+from app.schemas.open_meteo import OpenMeteoResponse, DailyForecast
 
 
 @pytest.fixture
@@ -26,7 +26,7 @@ def mock_calendar_service():
 
 @pytest.fixture
 def mock_weather_service():
-    with patch("app.api.v1.endpoints.cron.weather_service_instance") as mock_service:
+    with patch("app.api.v1.endpoints.cron.open_meteo_service_instance") as mock_service:
         yield mock_service
 
 
@@ -108,11 +108,16 @@ async def test_morning_digest_success(
     mock_calendar_service.get_today_events = AsyncMock(return_value=[event])
 
     # Mock weather service
-    mock_weather = MagicMock(spec=WeatherData)
-    mock_weather.city = "Kyiv"
-    mock_weather.temp = 20
-    mock_weather.description = "Clear sky"
-    mock_weather_service.get_current_weather_by_city_name = AsyncMock(
+    mock_weather = MagicMock(spec=OpenMeteoResponse)
+    mock_weather.city_name = "Kyiv"
+    mock_weather.current_temp = 20.0
+    mock_weather.current_conditions = "Clear sky"
+    forecast = MagicMock(spec=DailyForecast)
+    forecast.max_temp = 25.0
+    forecast.min_temp = 15.0
+    forecast.precipitation_prob_max = 10
+    mock_weather.daily_forecasts = [forecast]
+    mock_weather_service.get_weather = AsyncMock(
         return_value=mock_weather
     )
 
@@ -180,11 +185,16 @@ async def test_morning_digest_no_events(
     mock_calendar_service.get_today_events = AsyncMock(return_value=[])
 
     # Mock weather service
-    mock_weather = MagicMock(spec=WeatherData)
-    mock_weather.city = "Kyiv"
-    mock_weather.temp = 20
-    mock_weather.description = "Clear sky"
-    mock_weather_service.get_current_weather_by_city_name = AsyncMock(
+    mock_weather = MagicMock(spec=OpenMeteoResponse)
+    mock_weather.city_name = "Kyiv"
+    mock_weather.current_temp = 20.0
+    mock_weather.current_conditions = "Clear sky"
+    forecast = MagicMock(spec=DailyForecast)
+    forecast.max_temp = 25.0
+    forecast.min_temp = 15.0
+    forecast.precipitation_prob_max = 10
+    mock_weather.daily_forecasts = [forecast]
+    mock_weather_service.get_weather = AsyncMock(
         return_value=mock_weather
     )
 
@@ -269,11 +279,16 @@ async def test_morning_digest_with_emails(
     mock_calendar_service.get_today_events = AsyncMock(return_value=[event])
 
     # Mock weather service
-    mock_weather = MagicMock(spec=WeatherData)
-    mock_weather.city = "Kyiv"
-    mock_weather.temp = 20
-    mock_weather.description = "Clear sky"
-    mock_weather_service.get_current_weather_by_city_name = AsyncMock(
+    mock_weather = MagicMock(spec=OpenMeteoResponse)
+    mock_weather.city_name = "Kyiv"
+    mock_weather.current_temp = 20.0
+    mock_weather.current_conditions = "Clear sky"
+    forecast = MagicMock(spec=DailyForecast)
+    forecast.max_temp = 25.0
+    forecast.min_temp = 15.0
+    forecast.precipitation_prob_max = 10
+    mock_weather.daily_forecasts = [forecast]
+    mock_weather_service.get_weather = AsyncMock(
         return_value=mock_weather
     )
 
@@ -303,7 +318,7 @@ async def test_morning_digest_with_emails(
 
     # Verify gmail call
     mock_gmail_service.get_emails.assert_called_once_with(
-        user_id=user.id, db=db_session, query="is:unread", max_results=5
+        user_id=user.id, db=db_session, query="newer_than:1d", max_results=5
     )
 
     # Verify LLM call

--- a/backend/tests/api/test_cron.py
+++ b/backend/tests/api/test_cron.py
@@ -332,6 +332,73 @@ async def test_morning_digest_with_emails(
 
 
 @pytest.mark.asyncio
+async def test_morning_digest_weather_failure(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    mock_llm_service,
+    mock_calendar_service,
+    mock_weather_service,
+    mock_gmail_service,
+    mock_httpx_client,
+) -> None:
+    # Create test user in DB
+    user = User(
+        email="cron-digest-weather-fail@example.com",
+        hashed_password="hashedpassword",
+        telegram_id=98765,
+        city_name="Kyiv",
+        is_daily_summary_enabled=True,
+        google_refresh_token="valid-refresh-token",
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    # Mock gmail service
+    mock_gmail_service.get_emails = AsyncMock(return_value=[])
+
+    # Mock calendar events
+    mock_calendar_service.get_today_events = AsyncMock(return_value=[])
+
+    # Mock weather service to raise exception
+    mock_weather_service.get_weather = AsyncMock(
+        side_effect=RuntimeError("Weather API connection timed out")
+    )
+
+    # Mock LLM service
+    mock_llm_service.chat.return_value = "Good morning! Weather is unavailable but you have a good day."
+
+    # Mock Telegram API response
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_httpx_client.post.return_value = mock_response
+
+    # Send POST request with correct header secret
+    response = await client.post(
+        f"{settings.API_V1_STR}/cron/morning-digest",
+        headers={"X-Cron-Secret": settings.CRON_SECRET_KEY},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["sent_digests_count"] == 1
+
+    # Verify weather call was attempted
+    mock_weather_service.get_weather.assert_called_once_with(
+        city=user.city_name, days=1
+    )
+
+    # Verify LLM call
+    mock_llm_service.chat.assert_called_once()
+    
+    # Verify the prompt contained the fallback weather message
+    args = mock_llm_service.chat.call_args[0]
+    prompt = args[0]
+    assert "Не вдалося отримати дані про погоду." in prompt
+
+
+@pytest.mark.asyncio
 async def test_check_power_status_success(
     client: AsyncClient,
     db_session: AsyncSession,


### PR DESCRIPTION
This PR improves the daily morning digest by:
1. Fetching emails from the last 24 hours (using Gmail query 'newer_than:1d') rather than just unread emails ('is:unread'). This prevents old unread emails from clogging up the digest while ensuring recent read/unread emails are included.
2. Switching weather forecasting from OpenWeatherMap (current temperature only) to Open-Meteo (current temp, daily min/max, precipitation probability).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Daily morning digests now include weather information from the Open-Meteo service, including current conditions and available forecasts.
  * Email summaries now cover messages received within the past day instead of only unread messages.
  * Digest wording has been updated to reflect the revised weather and email information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->