### PR TITLE
fix(calendar): handle timezone offset and format all-day events properly

### DIFF
--- a/backend/app/api/v1/endpoints/cron.py
+++ b/backend/app/api/v1/endpoints/cron.py
@@ -78,7 +78,7 @@ async def send_daily_digests(db: AsyncSession) -> int:
             if events:
                 events_text = "\n".join(
                     [
-                        f"- {e.start_time.strftime('%H:%M') if e.start_time else 'All day'}: {e.summary}"
+                        f"- {'Весь день' if e.is_all_day else (e.start_time.strftime('%H:%M') if e.start_time else 'Весь день')}: {e.summary}"
                         for e in events
                     ]
                 )

--- a/backend/app/services/gemini_tools.py
+++ b/backend/app/services/gemini_tools.py
@@ -125,7 +125,9 @@ def create_tools(
 
             result = f"Upcoming events (next {days} days):\n"
             for i, event in enumerate(events, 1):
-                if event.start_time:
+                if event.is_all_day:
+                    start = f"All day ({event.start_time.strftime('%Y-%m-%d') if event.start_time else ''})".strip()
+                elif event.start_time:
                     start = event.start_time.strftime("%Y-%m-%d %H:%M")
                 else:
                     start = "All day"

--- a/backend/app/services/gemini_tools.py
+++ b/backend/app/services/gemini_tools.py
@@ -126,7 +126,11 @@ def create_tools(
             result = f"Upcoming events (next {days} days):\n"
             for i, event in enumerate(events, 1):
                 if event.is_all_day:
-                    start = f"All day ({event.start_time.strftime('%Y-%m-%d') if event.start_time else ''})".strip()
+                    start = (
+                        f"All day ({event.start_time.strftime('%Y-%m-%d')})"
+                        if event.start_time
+                        else "All day"
+                    )
                 elif event.start_time:
                     start = event.start_time.strftime("%Y-%m-%d %H:%M")
                 else:
@@ -173,7 +177,7 @@ def create_tools(
         - '2026-03-01T09:30:00' (March 1, 2026 at 9:30 AM)
         - '2026-12-25T18:00:00' (December 25, 2026 at 6:00 PM)
 
-        The time will be interpreted in Europe/Kiev timezone.
+        The time will be interpreted in Europe/Kyiv timezone.
 
         Args:
             summary: The title/name of the event (e.g., 'Team Meeting', 'Doctor Appointment')

--- a/backend/app/services/google_calendar.py
+++ b/backend/app/services/google_calendar.py
@@ -28,7 +28,7 @@ class GoogleCalendarService:
     def __init__(self) -> None:
         """Initialize the Google Calendar Service."""
         self.token_uri = "https://oauth2.googleapis.com/token"
-        self.timezone = "Europe/Kiev"
+        self.timezone = "Europe/Kyiv"
 
     async def _fetch_events_raw(
         self,
@@ -106,6 +106,16 @@ class GoogleCalendarService:
         except Exception as e:
             raise Exception(f"Failed to fetch calendar events: {str(e)}") from e
 
+    def _get_tz(self) -> ZoneInfo:
+        """Get ZoneInfo object with fallback for legacy timezone names."""
+        try:
+            return ZoneInfo(self.timezone)
+        except Exception:
+            try:
+                return ZoneInfo("Europe/Kyiv")
+            except Exception:
+                return ZoneInfo("Europe/Kiev")
+
     async def get_today_events(
         self, user_id: int, db: AsyncSession
     ) -> list["CalendarEvent"]:
@@ -119,7 +129,7 @@ class GoogleCalendarService:
         Returns:
             List of formatted CalendarEvent objects
         """
-        tz = ZoneInfo(self.timezone)
+        tz = self._get_tz()
         now_local = datetime.now(tz)
         time_min = datetime.combine(now_local.date(), time.min, tzinfo=tz)
         time_max = datetime.combine(now_local.date(), time.max, tzinfo=tz)
@@ -140,7 +150,7 @@ class GoogleCalendarService:
         Returns:
             List of formatted CalendarEvent objects
         """
-        tz = ZoneInfo(self.timezone)
+        tz = self._get_tz()
         now_local = datetime.now(tz)
         time_min = now_local
         time_max = now_local + timedelta(days=days)
@@ -266,7 +276,7 @@ class GoogleCalendarService:
 
     def _to_service_tz(self, dt: datetime) -> datetime:
         """Ensure a datetime object is timezone-aware in the service's configured timezone."""
-        tz = ZoneInfo(self.timezone)
+        tz = self._get_tz()
         return dt.replace(tzinfo=tz) if dt.tzinfo is None else dt.astimezone(tz)
 
     def _parse_datetime(self, dt_string: str | None) -> datetime | None:

--- a/backend/app/services/google_calendar.py
+++ b/backend/app/services/google_calendar.py
@@ -3,8 +3,8 @@ import json
 import logging
 from datetime import datetime, time, timedelta
 from typing import Any
+from zoneinfo import ZoneInfo
 
-import pytz
 from google.auth.exceptions import RefreshError
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
@@ -68,8 +68,10 @@ class GoogleCalendarService:
         service = await self._get_calendar_service(user_id, db)
 
         try:
-            time_min_str = time_min.isoformat() + "Z"
-            time_max_str = time_max.isoformat() + "Z"
+            time_min_aware = self._to_service_tz(time_min)
+            time_max_aware = self._to_service_tz(time_max)
+            time_min_str = time_min_aware.isoformat()
+            time_max_str = time_max_aware.isoformat()
 
             events_result = await asyncio.to_thread(
                 lambda: (
@@ -117,9 +119,10 @@ class GoogleCalendarService:
         Returns:
             List of formatted CalendarEvent objects
         """
-        now = datetime.utcnow()
-        time_min = datetime.combine(now.date(), time.min)
-        time_max = datetime.combine(now.date(), time.max)
+        tz = ZoneInfo(self.timezone)
+        now_local = datetime.now(tz)
+        time_min = datetime.combine(now_local.date(), time.min, tzinfo=tz)
+        time_max = datetime.combine(now_local.date(), time.max, tzinfo=tz)
         events = await self._fetch_events_raw(user_id, time_min, time_max, db)
         return self._format_events(events)
 
@@ -137,9 +140,10 @@ class GoogleCalendarService:
         Returns:
             List of formatted CalendarEvent objects
         """
-        now = datetime.utcnow()
-        time_min = now
-        time_max = now + timedelta(days=days)
+        tz = ZoneInfo(self.timezone)
+        now_local = datetime.now(tz)
+        time_min = now_local
+        time_max = now_local + timedelta(days=days)
         events = await self._fetch_events_raw(user_id, time_min, time_max, db)
         return self._format_events(events)
 
@@ -262,8 +266,8 @@ class GoogleCalendarService:
 
     def _to_service_tz(self, dt: datetime) -> datetime:
         """Ensure a datetime object is timezone-aware in the service's configured timezone."""
-        tz = pytz.timezone(self.timezone)
-        return tz.localize(dt) if dt.tzinfo is None else dt.astimezone(tz)
+        tz = ZoneInfo(self.timezone)
+        return dt.replace(tzinfo=tz) if dt.tzinfo is None else dt.astimezone(tz)
 
     def _parse_datetime(self, dt_string: str | None) -> datetime | None:
         """

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -1,8 +1,8 @@
 import datetime
 import logging
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
-import pytz
 from google import genai
 from google.genai import types
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -122,7 +122,13 @@ class LLMService:
 
                 result = f"Upcoming events (next {days} days):\n"
                 for i, event in enumerate(events, 1):
-                    if event.start_time:
+                    if event.is_all_day:
+                        start = (
+                            f"All day ({event.start_time.strftime('%Y-%m-%d')})"
+                            if event.start_time
+                            else "All day"
+                        )
+                    elif event.start_time:
                         start = event.start_time.strftime("%Y-%m-%d %H:%M")
                     else:
                         start = "All day"
@@ -193,7 +199,7 @@ class LLMService:
             - '2026-03-01T09:30:00' (March 1, 2026 at 9:30 AM)
             - '2026-12-25T18:00:00' (December 25, 2026 at 6:00 PM)
 
-            The time will be interpreted in Europe/Kiev timezone.
+            The time will be interpreted in Europe/Kyiv timezone.
 
             Args:
                 summary: The title/name of the event (e.g., 'Team Meeting', 'Doctor Appointment')
@@ -319,7 +325,10 @@ class LLMService:
         Returns:
             GenerateContentConfig with automatic function calling enabled
         """
-        tz = pytz.timezone("Europe/Kiev")
+        try:
+            tz = ZoneInfo("Europe/Kyiv")
+        except Exception:
+            tz = ZoneInfo("Europe/Kiev")
         now = datetime.datetime.now(tz)
         current_time_str = now.strftime("%Y-%m-%d %H:%M (%A)")
 

--- a/backend/tests/api/test_calendar.py
+++ b/backend/tests/api/test_calendar.py
@@ -567,3 +567,53 @@ async def test_delete_calendar_event_endpoint(
         assert mock_service.delete_event.call_args.args[1] == "event123"
     finally:
         app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_get_today_events_timezone_boundaries(
+    client: AsyncClient, db_session: AsyncSession, auth_user: dict
+) -> None:
+    """Test that get_today_events queries Google API with timezone-aware boundaries."""
+    user = auth_user["user"]
+    headers = auth_user["headers"]
+
+    await crud_user.update(
+        db_session, db_obj=user, obj_in={"google_refresh_token": "test_refresh_token"}
+    )
+
+    mock_all_day_item = {
+        "id": "allday123",
+        "summary": "All Day Conference",
+        "start": {"date": "2026-08-22"},
+        "end": {"date": "2026-08-23"},
+    }
+
+    with patch("app.services.google_calendar.build") as mock_build:
+        mock_service = MagicMock()
+        mock_events_list = MagicMock()
+        mock_events_list.execute.return_value = {"items": [mock_all_day_item]}
+        mock_service.events.return_value.list.return_value = mock_events_list
+        mock_build.return_value = mock_service
+
+        response = await client.get(
+            f"{settings.API_V1_STR}/calendar/events/today",
+            params={"user_id": user.id},
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 1
+        assert data["events"][0]["summary"] == "All Day Conference"
+        assert data["events"][0]["is_all_day"] is True
+
+        # Verify list() call arguments include timezone offset (e.g. +02:00 or +03:00)
+        call_kwargs = mock_service.events.return_value.list.call_args.kwargs
+        time_min_called = call_kwargs["timeMin"]
+        time_max_called = call_kwargs["timeMax"]
+        # Ensure timeMin and timeMax have valid timezone offsets (not naive + 'Z')
+        assert ("+02:00" in time_min_called or "+03:00" in time_min_called)
+        assert ("+02:00" in time_max_called or "+03:00" in time_max_called)
+        assert "00:00:00" in time_min_called
+        assert "23:59:59" in time_max_called
+

--- a/backend/tests/api/test_cron.py
+++ b/backend/tests/api/test_cron.py
@@ -331,6 +331,72 @@ async def test_morning_digest_with_emails(
 
 
 @pytest.mark.asyncio
+async def test_morning_digest_with_all_day_event(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    mock_llm_service,
+    mock_calendar_service,
+    mock_weather_service,
+    mock_gmail_service,
+    mock_httpx_client,
+) -> None:
+    # Create test user in DB
+    user = User(
+        email="cron-digest-allday@example.com",
+        hashed_password="hashedpassword",
+        telegram_id=112233,
+        city_name="Kyiv",
+        is_daily_summary_enabled=True,
+        google_refresh_token="valid-refresh-token",
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    # Mock gmail service
+    mock_gmail_service.get_emails = AsyncMock(return_value=[])
+
+    # Mock all-day calendar event
+    event = MagicMock()
+    event.start_time = datetime.datetime(2026, 8, 24, 0, 0)
+    event.is_all_day = True
+    event.summary = "Independence Day of Ukraine"
+    mock_calendar_service.get_today_events = AsyncMock(return_value=[event])
+
+    # Mock weather service
+    mock_weather = MagicMock(spec=OpenMeteoResponse)
+    mock_weather.city_name = "Kyiv"
+    mock_weather.current_temp = 22.0
+    mock_weather.current_conditions = "Sunny"
+    mock_weather.daily_forecasts = []
+    mock_weather_service.get_weather = AsyncMock(return_value=mock_weather)
+
+    # Mock LLM service
+    mock_llm_service.chat.return_value = "Доброго ранку! Сьогодні святковий день."
+
+    # Mock Telegram API response
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_httpx_client.post.return_value = mock_response
+
+    # Send POST request with correct header secret
+    response = await client.post(
+        f"{settings.API_V1_STR}/cron/morning-digest",
+        headers={"X-Cron-Secret": settings.CRON_SECRET_KEY},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["sent_digests_count"] == 1
+
+    # Verify prompt contains "Весь день: Independence Day of Ukraine" and NOT "00:00"
+    prompt = mock_llm_service.chat.call_args[0][0]
+    assert "Весь день: Independence Day of Ukraine" in prompt
+    assert "00:00: Independence Day of Ukraine" not in prompt
+
+
+@pytest.mark.asyncio
 async def test_morning_digest_weather_failure(
     client: AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/services/test_gemini_tools.py
+++ b/backend/tests/services/test_gemini_tools.py
@@ -97,6 +97,31 @@ class TestGetCalendarEvents:
             mock_cal.get_upcoming_events.assert_called_with(user_id=42, db=db, days=7)
 
     @pytest.mark.asyncio
+    async def test_all_day_event(self, tools):
+        tool_groups, db = tools
+        calendar_tool = tool_groups["calendar"][0]
+
+        with patch("app.services.gemini_tools.GoogleCalendarService") as MockCal:
+            mock_cal = MockCal.return_value
+            mock_cal.get_upcoming_events = AsyncMock()
+
+            event = MagicMock()
+            event.id = "allday1"
+            event.summary = "National Holiday"
+            event.start_time = datetime.datetime(2026, 8, 24, 0, 0)
+            event.is_all_day = True
+            event.location = None
+            event.description = None
+
+            mock_cal.get_upcoming_events.return_value = [event]
+
+            result = await calendar_tool(days=7)
+
+            assert "National Holiday" in result
+            assert "All day (2026-08-24)" in result
+            assert "[ID: allday1]" in result
+
+    @pytest.mark.asyncio
     async def test_no_events(self, tools):
         tool_groups, _ = tools
         calendar_tool = tool_groups["calendar"][0]

--- a/backend/tests/services/test_gemini_tools.py
+++ b/backend/tests/services/test_gemini_tools.py
@@ -122,6 +122,31 @@ class TestGetCalendarEvents:
             assert "[ID: allday1]" in result
 
     @pytest.mark.asyncio
+    async def test_all_day_event_without_start_time(self, tools):
+        tool_groups, db = tools
+        calendar_tool = tool_groups["calendar"][0]
+
+        with patch("app.services.gemini_tools.GoogleCalendarService") as MockCal:
+            mock_cal = MockCal.return_value
+            mock_cal.get_upcoming_events = AsyncMock()
+
+            event = MagicMock()
+            event.id = "allday2"
+            event.summary = "Spring Break"
+            event.start_time = None
+            event.is_all_day = True
+            event.location = None
+            event.description = None
+
+            mock_cal.get_upcoming_events.return_value = [event]
+
+            result = await calendar_tool(days=7)
+
+            assert "Spring Break" in result
+            assert "Spring Break [ID: allday2] - All day" in result
+            assert "All day ()" not in result
+
+    @pytest.mark.asyncio
     async def test_no_events(self, tools):
         tool_groups, _ = tools
         calendar_tool = tool_groups["calendar"][0]

--- a/backend/tests/services/test_llm.py
+++ b/backend/tests/services/test_llm.py
@@ -144,6 +144,50 @@ async def test_chat_extract_and_run_calendar_events_tool(
 
 
 @pytest.mark.asyncio
+async def test_chat_extract_and_run_calendar_events_tool_all_day(
+    llm_service, mock_genai_client
+):
+    mock_response = MagicMock()
+    mock_response.text = "Calendar response"
+    mock_genai_client.aio.models.generate_content.return_value = mock_response
+
+    db_session = AsyncMock()
+    await llm_service.chat("My events", [], 123, db_session)
+
+    calendar_tool = _extract_tool(mock_genai_client, "get_calendar_events")
+
+    with patch("app.services.llm.GoogleCalendarService") as MockCalendarService:
+        mock_calendar_service = MockCalendarService.return_value
+
+        # Mock all day event with start_time
+        event1 = MagicMock()
+        event1.summary = "All Day Festival"
+        event1.start_time = datetime.datetime(2026, 8, 24, 0, 0)
+        event1.is_all_day = True
+        event1.location = "Kyiv"
+        event1.description = None
+
+        # Mock all day event without start_time
+        event2 = MagicMock()
+        event2.summary = "Holiday"
+        event2.start_time = None
+        event2.is_all_day = True
+        event2.location = None
+        event2.description = None
+
+        mock_calendar_service.get_upcoming_events = AsyncMock(
+            return_value=[event1, event2]
+        )
+
+        result = await calendar_tool(days=7)
+
+        assert "1. All Day Festival - All day (2026-08-24) at Kyiv" in result
+        assert "2. Holiday - All day" in result
+        assert "All day ()" not in result
+        assert "00:00" not in result
+
+
+@pytest.mark.asyncio
 async def test_chat_extract_and_run_schedule_event_tool(llm_service, mock_genai_client):
     mock_response = MagicMock()
     mock_response.text = "Schedule response"


### PR DESCRIPTION
## Description
Fixes an issue where all-day events scheduled for tomorrow were appearing in today's morning digest with \

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * All-day calendar events now display as “Весь день” in daily digests instead of showing an incorrect time.
  * Calendar event dates and day boundaries now respect the configured local timezone.
  * Upcoming and same-day events are formatted more accurately, including all-day event dates.

* **Tests**
  * Added coverage for timezone-aware calendar boundaries and all-day event formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->